### PR TITLE
Rename export_format to export_formats, update README, typing

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Usage: nbautoexport [OPTIONS]
   upon save.
 
 Options:
-  -f, --export_formats TEXT  File format(s) to save for each notebook. Options
+  -f, --export_format TEXT   File format(s) to save for each notebook. Options
                              are 'script', 'html', 'markdown', and 'rst'.
                              Multiple formats should be provided using
                              multiple flags, e.g., '-f script -f html -f

--- a/nbautoexport/nbautoexport.py
+++ b/nbautoexport/nbautoexport.py
@@ -146,8 +146,9 @@ def install_sentinel(export_formats, organize_by, directory, overwrite):
 
 @click.command("autoexport")
 @click.option(
-    "--export_formats",
+    "--export_format",
     "-f",
+    "export_formats",
     multiple=True,
     default=["script"],
     help=(


### PR DESCRIPTION
Closes #1 

Decided for code clarity to rename `export_format` to `export_formats`. It makes it a bit weird that the command line flag is `--export_formats` but you have to provide a single format per flag, but I slightly prefer that. Also added a sentence to the help instructions to make absolutely clear how to use it.