### PR TITLE
Handle existing post_save hooks

### DIFF
--- a/nbautoexport/nbautoexport.py
+++ b/nbautoexport/nbautoexport.py
@@ -108,7 +108,17 @@ def install_post_save_hook():
     command = """# >>> nbautoexport initialize >>>
 try:
     from nbautoexport import post_save
-    c.FileContentsManager.post_save_hook = post_save
+
+    if callable(c.FileContentsManager.post_save_hook):
+        old_post_save = c.FileContentsManager.post_save_hook
+
+        def _post_save(model, os_path, contents_manager):
+            old_post_save(model, os_path, contents_manager)
+            post_save(model, os_path, contents_manager)
+
+        c.FileContentsManager.post_save_hook = _post_save
+    else:
+        c.FileContentsManager.post_save_hook = post_save
 except:
     pass
 # <<< nbautoexport initialize <<<"""


### PR DESCRIPTION
Append post_save instead of overwriting if one already exists. Resolves #2 

By default, if no post_save_hook is configured, it's this [funky `traitlets` object](https://github.com/jupyter/notebook/blob/df887b2edf7b52f7a4624382d0d112c02318cf98/notebook/services/contents/filemanager.py#L99) that does field validation. The validation Jupyter does is to check if the thing you assign is `callable`. 

I've tested this and it works. 