### PR TITLE
Proposal: Change directory to an argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jupyter notebook --generate-config
 To set up, run the following command from the root folder of your project:
 
 ```bash
-nbautoexport [--directory/-d] [--export-format/-f] [--export-format/-f] [--organize-by/-b] [--overwrite/-o] [--verbose/-v]
+nbautoexport [DIRECTORY] [--export-format/-f] [--export-format/-f] [--organize-by/-b] [--overwrite/-o] [--verbose/-v]
 ```
 
 Under the hood, this command performs two steps: 1) edits `jupyter_notebook_config.py` to add a post-save hook, and 2) creates a sentinel file `./notebooks/.nbautoexport`, a JSON file that contains the project-specific settings. Here is the default `.nbautoexport`:

--- a/tests/test_nbautoexport.py
+++ b/tests/test_nbautoexport.py
@@ -41,7 +41,7 @@ def test_refuse_overwrite(tmp_path_factory):
     directory = tmp_path_factory.mktemp("refuse_overwrite")
     (directory / ".nbautoexport").touch()
     runner = CliRunner()
-    result = runner.invoke(app, ["-d", str(directory)])
+    result = runner.invoke(app, [str(directory)])
     assert result.exit_code == 1
     assert "Detected existing autoexport configuration at" in result.output
 
@@ -51,7 +51,7 @@ def test_force_overwrite(tmp_path_factory):
     (directory / ".nbautoexport").touch()
     runner = CliRunner()
     result = runner.invoke(
-        app, ["-d", str(directory), "-o", "-f", "script", "-f", "html", "-b", "notebook"]
+        app, [str(directory), "-o", "-f", "script", "-f", "html", "-b", "notebook"]
     )
     print(result.output)
     print(result.exit_code)


### PR DESCRIPTION
- I propose we change `directory` to an argument. The main action of the command is to write a sentinel file to this directory. This feels more intuitive to me.
- Use typer's built-in validation and casting for `Path` types. 