### PR TITLE
Changes to defaults

### DIFF
--- a/nbautoexport/nbautoexport.py
+++ b/nbautoexport/nbautoexport.py
@@ -235,7 +235,7 @@ def install(
 @app.command()
 def configure(
     directory: Path = typer.Argument(
-        "notebooks",
+        ...,
         exists=True,
         file_okay=False,
         dir_okay=True,

--- a/nbautoexport/sentinel.py
+++ b/nbautoexport/sentinel.py
@@ -9,7 +9,7 @@ from nbautoexport.utils import logger
 
 SAVE_PROGRESS_INDICATOR_FILE = ".nbautoexport"
 DEFAULT_EXPORT_FORMATS = ["script"]
-DEFAULT_ORGANIZE_BY = "notebook"
+DEFAULT_ORGANIZE_BY = "extension"
 DEFAULT_CLEAN = False
 
 

--- a/tests/test_cli_configure.py
+++ b/tests/test_cli_configure.py
@@ -29,7 +29,7 @@ def test_configure_defaults(tmp_path):
 
 def test_configure_specified(tmp_path):
     export_formats = ["script", "html"]
-    organize_by = "extension"
+    organize_by = "notebook"
     clean = True
     assert export_formats != DEFAULT_EXPORT_FORMATS
     assert organize_by != DEFAULT_ORGANIZE_BY

--- a/tests/test_cli_configure.py
+++ b/tests/test_cli_configure.py
@@ -138,3 +138,10 @@ def test_configure_no_warning(tmp_path, monkeypatch):
     result = CliRunner().invoke(app, ["configure", str(tmp_path)])
     assert result.exit_code == 0
     assert "Warning:" not in result.output
+
+
+def test_configure_no_directory_error():
+    result = CliRunner().invoke(app, ["configure"])
+
+    assert result.exit_code == 2
+    assert "Error: Missing argument 'DIRECTORY'." in result.stdout


### PR DESCRIPTION
Proposing two changes to defaults

1. Remove default directory argument from `nbautoexport configure` command. (Previously `./notebooks`)
  - Having a default feels too opinionated, and I think it leads to unintuitive implicit behavior. 
2. Change default `organize_by` to `extension` (Previously `notebook`)
  - This just feels to me like it would be the more common choice, but open to debate.