### PR TITLE
Release workflow and Netlify docs website

### DIFF
--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -1,0 +1,43 @@
+name: docs-master
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build:
+    name: Build and publish docs
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
+
+      - name: Build docs
+        run: |
+          make docs
+
+      - name: Deploy docs to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./docs/site"
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build and publish new release
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements-dev.txt
+          pip install -e .
+
+      - name: Build package
+        run: |
+          echo "${{ github.event.release.tag_name }}"
+          PACKAGE_VERSION=$(nbautoexport --version)
+          echo $PACKAGE_VERSION
+          [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
+          make dist
+
+      - name: Publish to Test PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          user: ${{ secrets.PYPI_TEST_USERNAME }}
+          password: ${{ secrets.PYPI_TEST_PASSWORD }}
+          repository_url: https://test.pypi.org/legacy/
+          skip_existing: true
+
+      - name: Publish to Production PyPI
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          user: ${{ secrets.PYPI_PROD_USERNAME }}
+          password: ${{ secrets.PYPI_PROD_PASSWORD }}
+          skip_existing: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,25 @@ jobs:
           [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
           make dist
 
+      - name: Build docs
+        run: |
+          make docs
+
+      - name: Deploy docs to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./docs/site"
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1
+
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,11 +2,11 @@ name: tests
 
 on:
   push:
-    branches: [ master ]
+    branches: [master]
   pull_request:
   schedule:
     # Run every Sunday
-    - cron: '0 0 * * 0'
+    - cron: "0 0 * * 0"
 
 jobs:
   build:
@@ -18,43 +18,58 @@ jobs:
         python-version: [3.6, 3.7, 3.8]
 
     steps:
+      - uses: actions/checkout@v2
 
-    - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }} with Miniconda
+        uses: goanpeca/setup-miniconda@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          channels: conda-forge
 
-    - name: Set up Python ${{ matrix.python-version }} with Miniconda
-      uses: goanpeca/setup-miniconda@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-        channels: conda-forge
+      - name: Install dependencies
+        shell: bash -l {0}
+        run: |
+          which python
+          python --version
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          conda install pandoc
 
-    - name: Install dependencies
-      shell: bash -l {0}
-      run: |
-        which python
-        python --version
-        python -m pip install --upgrade pip
-        python -m pip install -r requirements-dev.txt
-        conda install pandoc
+      - name: Lint package
+        shell: bash -l {0}
+        run: |
+          make lint
 
-    - name: Lint package
-      shell: bash -l {0}
-      run: |
-        make lint
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          make test
 
-    - name: Run tests
-      shell: bash -l {0}
-      run: |
-        make test
+      - name: Test building documentation
+        shell: bash -l {0}
+        run: |
+          make docs
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
 
-    - name: Test building documentation
-      shell: bash -l {0}
-      run: |
-        make docs
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+      - name: Deploy site preview to Netlify
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./docs/site"
+          production-deploy: false
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: true
+          enable-commit-comment: false
+          overwrites-pull-request-comment: true
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1
 
-    - name: Upload coverage to codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: ./coverage.xml
-        fail_ci_if_error: true
-      if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+      - name: Upload coverage to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.xml
+          fail_ci_if_error: true
+        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -62,6 +62,7 @@ jobs:
           enable-pull-request-comment: true
           enable-commit-comment: false
           overwrites-pull-request-comment: true
+          alias: deploy-preview-${{ github.event.number }}
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -100,13 +100,10 @@ To run a subset of tests, for example:
 pytest tests/test_export.py
 ```
 
-## Deploying
+## Release Instructions (for maintainers)
 
-A reminder for the maintainers on how to deploy. Make sure all your changes are committed (including an entry in `HISTORY.md`). Then run:
+To release a new version of `nbautoexport`, create a new release using the [GitHub releases UI](https://github.com/drivendataorg/nbautoexport/releases/new). The tag version must have a prefix `v` and should have a semantic versioning format, e.g., `v0.1.0`.
 
-```bash
-git push
-git push --tags
-```
+On publishing of the release, the [`release`](https://github.com/drivendataorg/nbautoexport/blob/master/.github/workflows/release.yml) GitHub action workflow will be triggered. This workflow builds the package and publishes it to PyPI. You will be able to see the workflow status in the [Actions tab](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Arelease).
 
-Travis will then deploy to PyPI if tests pass.
+The built package for `nbautoexport` will automatically match the created git tag via [versioneer](https://github.com/warner/python-versioneer).


### PR DESCRIPTION
Testing workflow change: 

- As part of testing CI, will build docs and publish a Netlify preview.

New release workflow:

- Triggered by a release created via the GitHub UI
- Builds docs and does a production deploy to Netlify 
- Builds package, publishes to Test PyPI and production PyPI

I tested the new release workflow on a fork, and it all seems to work up through Test PyPI rejecting me because I'm trying to push nbautoexport on my personal account and it already exists on the drivendataorg account. https://github.com/jayqi/nbautoexport/runs/904791462?check_suite_focus=true