### PR TITLE
Add deploy badge for docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # nbautoexport
 
-[![tests](https://github.com/drivendataorg/nbautoexport/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Atests+branch%3Amaster)
+| | |
+| --: | :-- |
+| tests | [![tests](https://github.com/drivendataorg/nbautoexport/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Atests+branch%3Amaster)
+| docs | [![Docs Status](https://api.netlify.com/api/v1/badges/d16bbd7e-36f9-498f-b0db-b3144b8bb93e/deploy-status)](https://nbautoexport.drivendata.org/) |
 
 > Making it easier to code review Jupyter notebooks, one script at a time.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 | | |
 | --: | :-- |
+| docs | [![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://nbautoexport.drivendata.org/) |
+| package | [![PyPI](https://img.shields.io/pypi/v/nbautoexport.svg)](https://pypi.org/project/nbautoexport/) |
 | tests | [![tests](https://github.com/drivendataorg/nbautoexport/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Atests+branch%3Amaster)
-| docs | [![Docs Status](https://api.netlify.com/api/v1/badges/d16bbd7e-36f9-498f-b0db-b3144b8bb93e/deploy-status)](https://nbautoexport.drivendata.org/) |
+| coverage | [![codecov](https://codecov.io/gh/drivendataorg/nbautoexport/branch/master/graph/badge.svg)](https://codecov.io/gh/drivendataorg/nbautoexport) |
 
 > Making it easier to code review Jupyter notebooks, one script at a time.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,9 @@
 # nbautoexport
 
-| | |
-| --: | :-- |
-| docs | [![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://nbautoexport.drivendata.org/) |
-| package | [![PyPI](https://img.shields.io/pypi/v/nbautoexport.svg)](https://pypi.org/project/nbautoexport/) |
-| tests | [![tests](https://github.com/drivendataorg/nbautoexport/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Atests+branch%3Amaster)
-| coverage | [![codecov](https://codecov.io/gh/drivendataorg/nbautoexport/branch/master/graph/badge.svg)](https://codecov.io/gh/drivendataorg/nbautoexport) |
+[![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://nbautoexport.drivendata.org/)
+[![PyPI](https://img.shields.io/pypi/v/nbautoexport.svg)](https://pypi.org/project/nbautoexport/)
+[![tests](https://github.com/drivendataorg/nbautoexport/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Atests+branch%3Amaster)
+[![codecov](https://codecov.io/gh/drivendataorg/nbautoexport/branch/master/graph/badge.svg)](https://codecov.io/gh/drivendataorg/nbautoexport)
 
 > Making it easier to code review Jupyter notebooks, one script at a time.
 


### PR DESCRIPTION
Tried adding the badge from netlify, but seems like the badge does not accurately reflect GH Action builds. Will look in to updating with a badge that works.

The cooler part is I setup the DNS for nbautoexport.drivendata.org