### PR TITLE
Fix missing requirements.txt for source install

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,6 +45,13 @@ jobs:
         run: |
           make test
 
+      - name: Build distribution and test installation
+        shell: bash -l {0}
+        run: |
+          make dist
+          python -m pip install dist/nbautoexport-*.whl --no-deps --force-reinstall
+          python -m pip install dist/nbautoexport-*.tar.gz --no-deps --force-reinstall
+
       - name: Test building documentation
         shell: bash -l {0}
         run: |

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## 0.1.1 (2020-08-05)
+
+- Fixes missing `requirements.txt` bug when installing from source distribution. ([#50](https://github.com/drivendataorg/nbautoexport/issues/50), [#52](https://github.com/drivendataorg/nbautoexport/pull/52))
+
 ## 0.1.0 (2020-08-05)
 
 - First release on PyPI.

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,6 @@
 # History
 
-## 0.1.1 (2020-08-05)
+## Unreleased
 
 - Fixes missing `requirements.txt` bug when installing from source distribution. ([#50](https://github.com/drivendataorg/nbautoexport/issues/50), [#52](https://github.com/drivendataorg/nbautoexport/pull/52))
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -5,5 +5,8 @@ include README.md
 
 recursive-include tests *
 recursive-exclude * __pycache__ *.py[co]
+
+include requirements.txt
+
 include versioneer.py
 include nbautoexport/_version.py


### PR DESCRIPTION
- Add requirements.txt to MANIFEST.in (fixes #50)
- Add CI step to build distributions and try installing, to catch this type of problem in the future