### PR TITLE
Add exclude config option for clean

### DIFF
--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements-dev.txt --use-feature=2020-resolver
           pip install -e .
 
       - name: Build docs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt
+          pip install -r requirements-dev.txt --use-feature=2020-resolver
           pip install -e .
 
       - name: Build package

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           which python
           python --version
           python -m pip install --upgrade pip
-          python -m pip install -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt --use-feature=2020-resolver
           conda install pandoc
 
       - name: Lint package

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+## Unreleased
+
+- Add option to specify glob-style patterns to exclude files from deletion when using `clean`. See [documentation](https://nbautoexport.drivendata.org/cleaning/#excluding-files) for more details. ([#46](https://github.com/drivendataorg/nbautoexport/issues/46), [#54](https://github.com/drivendataorg/nbautoexport/pull/54))
+
 ## 0.1.1 (2020-08-06)
 
 - Fixes missing `requirements.txt` bug when installing from source distribution. ([#50](https://github.com/drivendataorg/nbautoexport/issues/50), [#52](https://github.com/drivendataorg/nbautoexport/pull/52))

--- a/docs/docs/cleaning.md
+++ b/docs/docs/cleaning.md
@@ -24,7 +24,7 @@ Identified following files to clean up:
 Are you sure you want to delete these files? [y/N]: █
 ```
 
-At this point, you can enter `y` to continue with the deletion or `N` to cancel the deletion. There is also a `--dry-run` flag to automatically exit at this point without prompting to continue with deletion.
+At this point, you can enter `y` to continue with the deletion or `n` to cancel the deletion. Alternatively, you can run the `clean` command with the `--dry-run` flag which will automatically exit at this point without performing any file deletion.
 
 ## How it works
 
@@ -32,9 +32,6 @@ Let's say you have the following files:
 
 ```text
 notebooks/
-├── .ipynb_checkpoints
-│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
-│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
 ├── .nbautoexport
 ├── 0.1-ejm-data-exploration.ipynb
 ├── 0.2-ejm-feature-creation.ipynb
@@ -83,9 +80,6 @@ After running `clean`, we end up with the following files:
 
 ```text
 notebooks/
-├── .ipynb_checkpoints
-│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
-│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
 ├── .nbautoexport
 ├── 0.1-ejm-data-exploration.ipynb
 ├── 0.2-ejm-feature-creation.ipynb
@@ -102,9 +96,6 @@ Building on the previous example, let's say we have the following files:
 
 ```text
 notebooks/
-├── .ipynb_checkpoints
-│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
-│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
 ├── .nbautoexport
 ├── 0.1-ejm-data-exploration.ipynb
 ├── 0.2-ejm-feature-creation.ipynb
@@ -172,9 +163,6 @@ We can see that `README.md` and `images/diagram.png` are left alone.
 
 ```text
 notebooks/
-├── .ipynb_checkpoints
-│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
-│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
 ├── .nbautoexport
 ├── 0.1-ejm-data-exploration.ipynb
 ├── 0.2-ejm-feature-creation.ipynb

--- a/docs/docs/cleaning.md
+++ b/docs/docs/cleaning.md
@@ -1,0 +1,203 @@
+# Cleaning (Experimental)
+
+While using `nbautoexport`, you may sometimes end up with leftover files you no longer want. Some ways this can happen are if you rename notebooks, or if you change your export configuration. The `nbautoexport` CLI has an experimental `clean` command to delete extraneous files.
+
+**WARNING: the `clean` command can delete files irreversibly. Please use with care.**
+
+## Basic usage
+
+Let's say you have a project and keep your notebooks in a `notebooks/` subdirectory. You can clean it with:
+
+```bash
+nbautoexport clean notebooks/
+```
+
+Note that in order to use `clean`, this directory _must_ be configured with `nbautoexport`, i.e., you have a `notebooks/.nbautoexport` configuration file.
+
+If you have some files that would be cleaned, you would see something that looks like this:
+
+```text
+Identified following files to clean up:
+  notebooks/html/0.1-ejm-data-exploration.html
+  notebooks/html/0.2-ejm-feature-creation.html
+  notebooks/script/Untitled.py
+Are you sure you want to delete these files? [y/N]: █
+```
+
+At this point, you can enter `y` to continue with the deletion or `N` to cancel the deletion. There is also a `--dry-run` flag to automatically exit at this point without prompting to continue with deletion.
+
+## How it works
+
+Let's say you have the following files:
+
+```text
+notebooks/
+├── .ipynb_checkpoints
+│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
+│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
+├── .nbautoexport
+├── 0.1-ejm-data-exploration.ipynb
+├── 0.2-ejm-feature-creation.ipynb
+├── html
+│   ├── 0.1-ejm-data-exploration.html
+│   └── 0.2-ejm-feature-creation.html
+└── script
+    ├── 0.1-ejm-data-exploration.py
+    ├── 0.2-ejm-feature-creation.py
+    └── Untitled.py
+```
+
+and you have the following `.nbautoexport` configuration:
+
+```json
+{
+  "export_formats": [
+    "script"
+  ],
+  "organize_by": "extension"
+}
+```
+
+We have some extra files that we want to clean up:
+
+- `html/` has some exports from when we earlier had `html` as an export format.
+- `script/Untitled.py` got saved when we had an `Untitled.ipynb` notebook before it was renamed.
+
+`nbautoexport`, based on the configuration file and the notebooks it finds, identifies which files are expected exports or other expected files based on normal `nbautoexport` and Jupyter usage. All other files found are marked for clean up.
+
+```ShellSession
+$ nbautoexport clean notebooks/
+
+Identified following files to clean up:
+  notebooks/html/0.1-ejm-data-exploration.html
+  notebooks/html/0.2-ejm-feature-creation.html
+  notebooks/script/Untitled.py
+Are you sure you want to delete these files? [y/N]: y
+Removing identified files...
+Removing empty subdirectories...
+  notebooks/html
+Cleaning complete.
+```
+
+After running `clean`, we end up with the following files:
+
+```text
+notebooks/
+├── .ipynb_checkpoints
+│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
+│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
+├── .nbautoexport
+├── 0.1-ejm-data-exploration.ipynb
+├── 0.2-ejm-feature-creation.ipynb
+└── script
+    ├── 0.1-ejm-data-exploration.py
+    └── 0.2-ejm-feature-creation.py
+```
+
+## Excluding files
+
+Sometimes you may have additional files in the notebooks directory of your project that are intentional. You can use [glob-style patterns](https://docs.python.org/3/library/glob.html) indicate files to exclude from deletion.
+
+Building on the previous example, let's say we have the following files:
+
+```text
+notebooks/
+├── .ipynb_checkpoints
+│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
+│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
+├── .nbautoexport
+├── 0.1-ejm-data-exploration.ipynb
+├── 0.2-ejm-feature-creation.ipynb
+├── README.md
+├── html
+│   ├── 0.1-ejm-data-exploration.html
+│   └── 0.2-ejm-feature-creation.html
+├── images
+│   └── diagram.png
+└── script
+    ├── 0.1-ejm-data-exploration.py
+    ├── 0.2-ejm-feature-creation.py
+    └── Untitled.py
+```
+
+We have additional files that we want to keep:
+
+- `README.md`
+- `images/diagram.png`
+
+We can specify [glob-style patterns](https://docs.python.org/3/library/glob.html) to exclude from cleaning with the `--clean-exclude` flag in the `configure` command. Alternatively, we could also directly manually edit the `.nbautoexport` configuration file.
+
+```bash
+nbautoexport configure notebooks/ \
+    --overwrite \
+    --clean-exclude README.md \
+    --clean-exclude images/*
+```
+
+```json
+{
+  "export_formats": [
+    "script"
+  ],
+  "organize_by": "extension",
+  "clean": {
+    "exclude": [
+      "README.md",
+      "images/*"
+    ]
+  }
+}
+```
+
+Then, running the `clean` command:
+
+```ShellSession
+$ nbautoexport clean notebooks/
+
+Excluding files from cleaning using the following patterns:
+  README.md
+  images/*
+Identified following files to clean up:
+  notebooks/html/0.1-ejm-data-exploration.html
+  notebooks/html/0.2-ejm-feature-creation.html
+  notebooks/script/Untitled.py
+Are you sure you want to delete these files? [y/N]: y
+Removing identified files...
+Removing empty subdirectories...
+  notebooks/html
+Cleaning complete.
+```
+
+We can see that `README.md` and `images/diagram.png` are left alone.
+
+```text
+notebooks/
+├── .ipynb_checkpoints
+│   ├── 0.1-ejm-data-exploration-checkpoint.ipynb
+│   └── 0.2-ejm-feature-creation-checkpoint.ipynb
+├── .nbautoexport
+├── 0.1-ejm-data-exploration.ipynb
+├── 0.2-ejm-feature-creation.ipynb
+├── README.md
+├── images
+│   └── diagram.png
+└── script
+    ├── 0.1-ejm-data-exploration.py
+    └── 0.2-ejm-feature-creation.py
+```
+
+### `--exclude` flag
+
+You can also provide patterns to exclude with the `--exclude` (`-e`) flag when calling `clean`.
+
+```bash
+nbautoexport clean notebooks/ \
+    --exclude README.md \
+    --exclude images/*
+```
+
+Any patterns specified this way will be used *in addition* to the patterns in the `.nbautoexport` configuration.
+
+## Experimental status
+
+The `clean` command is experimental. The logic for identifying files to delete may be in need of improvement. If you have any feedback from using the `clean` command, please let us know by [creating a GitHub issue](https://github.com/drivendataorg/nbautoexport/issues).

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -6,18 +6,19 @@ theme:
   name: material
 
 nav:
-  - Home: 'index.md'
+  - Home: "index.md"
+  - Cleaning (Experimental): "cleaning.md"
   - Command Reference:
-    - 'nbautoexport clean' : 'command-reference/clean.md'
-    - 'nbautoexport configure' : 'command-reference/configure.md'
-    - 'nbautoexport export' : 'command-reference/export.md'
-    - 'nbautoexport install' : 'command-reference/install.md'
+      - "nbautoexport clean": "command-reference/clean.md"
+      - "nbautoexport configure": "command-reference/configure.md"
+      - "nbautoexport export": "command-reference/export.md"
+      - "nbautoexport install": "command-reference/install.md"
   - API Reference:
-    - 'nbautoexport.clean' : 'api-reference/nbautoexport-clean.md'
-    - 'nbautoexport.export' : 'api-reference/nbautoexport-export.md'
-    - 'nbautoexport.jupyter_config' : 'api-reference/nbautoexport-jupyter_config.md'
-    - 'nbautoexport.sentinel' : 'api-reference/nbautoexport-sentinel.md'
-    - 'nbautoexport.utils' : 'api-reference/nbautoexport-utils.md'
+      - "nbautoexport.clean": "api-reference/nbautoexport-clean.md"
+      - "nbautoexport.export": "api-reference/nbautoexport-export.md"
+      - "nbautoexport.jupyter_config": "api-reference/nbautoexport-jupyter_config.md"
+      - "nbautoexport.sentinel": "api-reference/nbautoexport-sentinel.md"
+      - "nbautoexport.utils": "api-reference/nbautoexport-utils.md"
 
 plugins:
   - search

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -44,8 +44,7 @@ version_regex = re.compile(r"(?<=# >>> nbautoexport initialize, version=\[).*(?=
 
 
 def install_post_save_hook(config_path: Optional[Path] = None):
-    """Splices the post save hook into the global Jupyter configuration file
-    """
+    """Splices the post save hook into the global Jupyter configuration file"""
     if config_path is None:
         config_dir = jupyter_config_dir()
         config_path = Path(config_dir) / "jupyter_notebook_config.py"

--- a/nbautoexport/sentinel.py
+++ b/nbautoexport/sentinel.py
@@ -49,8 +49,7 @@ class NbAutoexportConfig(BaseModel):
 
 
 def install_sentinel(directory: Path, config: NbAutoexportConfig, overwrite: bool):
-    """Writes the configuration file to a specified directory.
-    """
+    """Writes the configuration file to a specified directory."""
     sentinel_path = directory / SAVE_PROGRESS_INDICATOR_FILE
 
     if sentinel_path.exists() and (not overwrite):

--- a/nbautoexport/sentinel.py
+++ b/nbautoexport/sentinel.py
@@ -35,9 +35,14 @@ DEFAULT_EXPORT_FORMATS = [ExportFormat.script]
 DEFAULT_ORGANIZE_BY = OrganizeBy.extension
 
 
+class CleanConfig(BaseModel):
+    exclude: List[str] = []
+
+
 class NbAutoexportConfig(BaseModel):
     export_formats: List[ExportFormat] = [ExportFormat(fmt) for fmt in DEFAULT_EXPORT_FORMATS]
     organize_by: OrganizeBy = OrganizeBy(DEFAULT_ORGANIZE_BY)
+    clean: CleanConfig = CleanConfig()
 
     class Config:
         extra = "forbid"

--- a/tests/test_clean.py
+++ b/tests/test_clean.py
@@ -24,8 +24,7 @@ def notebooks_dir(tmp_path, notebook_asset):
     "export_format, organize_by", itertools.product(EXPORT_FORMATS_TO_TEST, OrganizeBy)
 )
 def test_notebook_exports_generator(notebooks_dir, export_format, organize_by):
-    """Test that notebook_exports_generator matches what export_notebook produces.
-    """
+    """Test that notebook_exports_generator matches what export_notebook produces."""
     notebook = find_notebooks(notebooks_dir)[0]
     notebook_files = {notebooks_dir / f"{nb}.ipynb" for nb in EXPECTED_NOTEBOOKS}
 

--- a/tests/test_cli_clean.py
+++ b/tests/test_cli_clean.py
@@ -7,7 +7,12 @@ from typer.testing import CliRunner
 
 from nbautoexport.clean import get_expected_exports, get_extension
 from nbautoexport.nbautoexport import app
-from nbautoexport.sentinel import ExportFormat, NbAutoexportConfig, SAVE_PROGRESS_INDICATOR_FILE
+from nbautoexport.sentinel import (
+    CleanConfig,
+    ExportFormat,
+    NbAutoexportConfig,
+    SAVE_PROGRESS_INDICATOR_FILE,
+)
 from nbautoexport.utils import JupyterNotebook, working_directory
 
 EXPECTED_NOTEBOOKS = [f"the_notebook_{n}" for n in range(3)]
@@ -132,6 +137,65 @@ def test_clean_relative_subdirectory(notebooks_dir, organize_by):
 
         # Run clean again, there should be nothing to do
         result_rerun = CliRunner().invoke(app, ["clean", "subdir"])
+        assert result_rerun.exit_code == 0
+        assert result_rerun.stdout.strip().endswith("No files identified for cleaning. Exiting.")
+
+
+def test_clean_exclude(notebooks_dir):
+    """ Test that cleaning works with exclude
+    """
+    with working_directory(notebooks_dir):
+        # Set up subdirectory
+        subdir = Path("subdir")
+        subdir.mkdir()
+        for subfile in Path().iterdir():
+            shutil.move(str(subfile), str(subdir))
+
+        # Set up extra files
+        extra_files = [
+            subdir / "keep.txt",
+            subdir / "delete.txt",
+            subdir / "images" / "keep.jpg",
+            subdir / "images" / "delete.png",
+            subdir / "pictures" / "delete.jpg",
+            subdir / "keep.md",
+            subdir / "docs" / "keep.md",
+        ]
+        for extra_file in extra_files:
+            extra_file.parent.mkdir(exist_ok=True)
+            extra_file.touch()
+
+        sentinel_path = subdir / SAVE_PROGRESS_INDICATOR_FILE
+        config = NbAutoexportConfig(
+            export_formats=EXPECTED_FORMATS,
+            organize_by="extension",
+            clean=CleanConfig(exclude=["keep.txt", "images/*.jpg"]),
+        )
+        with sentinel_path.open("w") as fp:
+            fp.write(config.json())
+
+        command = ["clean", "subdir", "-e", "**/*.md"]
+        result = CliRunner().invoke(app, command, input="y")
+        assert result.exit_code == 0
+
+        expected_notebooks = [
+            JupyterNotebook.from_file(subdir / f"{nb}.ipynb") for nb in EXPECTED_NOTEBOOKS
+        ]
+        expected_exports = set(get_expected_exports(expected_notebooks, config))
+        expected_extra = {
+            extra_file for extra_file in extra_files if extra_file.match("keep.*")
+        } | {subdir / "images", subdir / "docs"}
+
+        all_expected = (
+            {nb.path for nb in expected_notebooks}
+            | expected_exports
+            | {sentinel_path}
+            | expected_extra
+        )
+        assert set(subdir.glob("**/*")) == all_expected
+
+        # Run clean again, there should be nothing to do
+        result_rerun = CliRunner().invoke(app, command)
         assert result_rerun.exit_code == 0
         assert result_rerun.stdout.strip().endswith("No files identified for cleaning. Exiting.")
 

--- a/tests/test_cli_clean.py
+++ b/tests/test_cli_clean.py
@@ -83,8 +83,7 @@ def test_clean(notebooks_dir, need_confirmation, organize_by):
 
 @pytest.mark.parametrize("organize_by", ["extension", "notebook"])
 def test_clean_relative(notebooks_dir, organize_by):
-    """ Test that cleaning works relative to current working directory.
-    """
+    """Test that cleaning works relative to current working directory."""
     with working_directory(notebooks_dir):
         sentinel_path = Path(SAVE_PROGRESS_INDICATOR_FILE)
         config = NbAutoexportConfig(export_formats=EXPECTED_FORMATS, organize_by=organize_by)
@@ -110,8 +109,7 @@ def test_clean_relative(notebooks_dir, organize_by):
 
 @pytest.mark.parametrize("organize_by", ["extension", "notebook"])
 def test_clean_relative_subdirectory(notebooks_dir, organize_by):
-    """ Test that cleaning works for subdirectory relative to current working directory.
-    """
+    """Test that cleaning works for subdirectory relative to current working directory."""
     with working_directory(notebooks_dir):
         # Set up subdirectory
         subdir = Path("subdir")
@@ -142,8 +140,7 @@ def test_clean_relative_subdirectory(notebooks_dir, organize_by):
 
 
 def test_clean_exclude(notebooks_dir):
-    """ Test that cleaning works with exclude
-    """
+    """Test that cleaning works with exclude"""
     with working_directory(notebooks_dir):
         # Set up subdirectory
         subdir = Path("subdir")

--- a/tests/test_cli_configure.py
+++ b/tests/test_cli_configure.py
@@ -7,6 +7,7 @@ from typer.testing import CliRunner
 from nbautoexport import jupyter_config
 from nbautoexport.nbautoexport import app
 from nbautoexport.sentinel import (
+    CleanConfig,
     DEFAULT_EXPORT_FORMATS,
     DEFAULT_ORGANIZE_BY,
     NbAutoexportConfig,
@@ -29,6 +30,7 @@ def test_configure_defaults(tmp_path):
 def test_configure_specified(tmp_path):
     export_formats = ["script", "html"]
     organize_by = "notebook"
+    clean_exclude = ["README.md", "images/*"]
     assert export_formats != DEFAULT_EXPORT_FORMATS
     assert organize_by != DEFAULT_ORGANIZE_BY
 
@@ -36,6 +38,8 @@ def test_configure_specified(tmp_path):
     for fmt in export_formats:
         cmd_list.extend(["-f", fmt])
     cmd_list.extend(["-b", organize_by])
+    for excl in clean_exclude:
+        cmd_list.extend(["-e", excl])
 
     result = CliRunner().invoke(app, cmd_list)
     assert result.exit_code == 0
@@ -44,7 +48,11 @@ def test_configure_specified(tmp_path):
         path=tmp_path / SAVE_PROGRESS_INDICATOR_FILE, content_type="application/json"
     )
 
-    expected_config = NbAutoexportConfig(export_formats=export_formats, organize_by=organize_by)
+    expected_config = NbAutoexportConfig(
+        export_formats=export_formats,
+        organize_by=organize_by,
+        clean=CleanConfig(exclude=clean_exclude),
+    )
     assert config == expected_config
 
 

--- a/tests/test_cli_export.py
+++ b/tests/test_cli_export.py
@@ -28,8 +28,7 @@ def notebooks_dir(tmp_path, notebook_asset):
 
 @pytest.mark.parametrize("input_type", ["dir", "notebook"])
 def test_export_no_config_no_cli_opts(notebooks_dir, input_type):
-    """Test export command with no config file and no CLI options. Should use default options.
-    """
+    """Test export command with no config file and no CLI options. Should use default options."""
     expected_notebooks = find_notebooks(notebooks_dir)
     assert len(expected_notebooks) == len(EXPECTED_NOTEBOOKS)
 
@@ -54,8 +53,7 @@ def test_export_no_config_no_cli_opts(notebooks_dir, input_type):
     "input_type, organize_by", product(["dir", "notebook"], ["extension", "notebook"])
 )
 def test_export_no_config_with_cli_opts(notebooks_dir, input_type, organize_by):
-    """Test export command with no config file and CLI options. Should use CLI options.
-    """
+    """Test export command with no config file and CLI options. Should use CLI options."""
     expected_notebooks = find_notebooks(notebooks_dir)
     assert len(expected_notebooks) == len(EXPECTED_NOTEBOOKS)
 
@@ -84,8 +82,7 @@ def test_export_no_config_with_cli_opts(notebooks_dir, input_type, organize_by):
     "input_type, organize_by", product(["dir", "notebook"], ["extension", "notebook"])
 )
 def test_export_with_config_no_cli_opts(notebooks_dir, input_type, organize_by):
-    """Test that export works with a config and no CLI options. Should use config options.
-    """
+    """Test that export works with a config and no CLI options. Should use config options."""
     expected_notebooks = find_notebooks(notebooks_dir)
     assert len(expected_notebooks) == len(EXPECTED_NOTEBOOKS)
 
@@ -115,8 +112,7 @@ def test_export_with_config_no_cli_opts(notebooks_dir, input_type, organize_by):
     "input_type, organize_by", product(["dir", "notebook"], ["extension", "notebook"])
 )
 def test_export_with_config_with_cli_opts(notebooks_dir, input_type, organize_by):
-    """Test that export works with both config and CLI options. CLI options should overide config.
-    """
+    """Test that export works with both config and CLI options. CLI options should overide config."""
     expected_notebooks = find_notebooks(notebooks_dir)
     assert len(expected_notebooks) == len(EXPECTED_NOTEBOOKS)
 
@@ -153,8 +149,7 @@ def test_export_with_config_with_cli_opts(notebooks_dir, input_type, organize_by
     "input_type, organize_by", product(["dir", "notebook"], ["extension", "notebook"])
 )
 def test_export_relative(notebooks_dir, input_type, organize_by):
-    """ Test that export works relative to current working directory.
-    """
+    """Test that export works relative to current working directory."""
     with working_directory(notebooks_dir):
         expected_notebooks = find_notebooks(Path())
         assert len(expected_notebooks) == len(EXPECTED_NOTEBOOKS)
@@ -185,8 +180,7 @@ def test_export_relative(notebooks_dir, input_type, organize_by):
     "input_type, organize_by", product(["dir", "notebook"], ["extension", "notebook"])
 )
 def test_clean_relative_subdirectory(notebooks_dir, input_type, organize_by):
-    """ Test that export works for subdirectory relative to current working directory.
-    """
+    """Test that export works for subdirectory relative to current working directory."""
     with working_directory(notebooks_dir):
         # Set up subdirectory
         subdir = Path("subdir")

--- a/tests/test_export.py
+++ b/tests/test_export.py
@@ -49,8 +49,7 @@ def test_export_notebook(notebooks_dir, organize_by):
 
 
 def test_post_save_no_sentinel(notebooks_dir):
-    """Test that post_save does nothing with no sentinel file.
-    """
+    """Test that post_save does nothing with no sentinel file."""
     notebook_path = notebooks_dir / "the_notebook.ipynb"
     sentinel_path = notebooks_dir / SAVE_PROGRESS_INDICATOR_FILE
 
@@ -107,8 +106,7 @@ def test_post_save_organize_by_extension(notebooks_dir):
 
 
 def test_post_save_type_file(notebooks_dir):
-    """Test that post_save should do nothing if model type is 'file'.
-    """
+    """Test that post_save should do nothing if model type is 'file'."""
     notebook_path = notebooks_dir / "the_notebook.ipynb"
     sentinel_path = notebooks_dir / SAVE_PROGRESS_INDICATOR_FILE
     with sentinel_path.open("w") as fp:
@@ -124,8 +122,7 @@ def test_post_save_type_file(notebooks_dir):
 
 
 def test_post_save_type_directory(notebooks_dir):
-    """Test that post_save should do nothing if model type is 'directory'.
-    """
+    """Test that post_save should do nothing if model type is 'directory'."""
     notebook_path = notebooks_dir / "the_notebook.ipynb"
     sentinel_path = notebooks_dir / SAVE_PROGRESS_INDICATOR_FILE
     with sentinel_path.open("w") as fp:

--- a/tests/test_jupyter_config.py
+++ b/tests/test_jupyter_config.py
@@ -204,8 +204,7 @@ def test_install_hook_replace_hook_older_version(tmp_path, monkeypatch):
 
 
 def test_initialize_post_save_binding():
-    """Test that post_save hook can be successfully bound to a Jupyter config.
-    """
+    """Test that post_save hook can be successfully bound to a Jupyter config."""
     jupyter_config_obj = Config(FileContentsManager=FileContentsManager())
     jupyter_config.initialize_post_save_hook(jupyter_config_obj)
     assert isinstance(jupyter_config_obj.FileContentsManager, FileContentsManager)
@@ -213,14 +212,12 @@ def test_initialize_post_save_binding():
 
 
 def test_initialize_post_save_execution(monkeypatch):
-    """Test that bound post_save hook with given signature can be successfully run.
-    """
+    """Test that bound post_save hook with given signature can be successfully run."""
 
     jupyter_config_obj = Config(FileContentsManager=FileContentsManager())
 
     def mocked_post_save(model, os_path, contents_manager):
-        """Append a token to os_path to certify that function ran.
-        """
+        """Append a token to os_path to certify that function ran."""
         os_path.append("nbautoexport")
 
     monkeypatch.setattr(nbautoexport_root, "post_save", mocked_post_save)
@@ -235,21 +232,18 @@ def test_initialize_post_save_execution(monkeypatch):
 
 
 def test_initialize_post_save_existing(monkeypatch):
-    """Test that handling of existing post_save hook works properly.
-    """
+    """Test that handling of existing post_save hook works properly."""
 
     jupyter_config_obj = Config(FileContentsManager=FileContentsManager())
 
     def old_post_save(model, os_path, contents_manager):
-        """Append a token to os_path to certify that function ran.
-        """
+        """Append a token to os_path to certify that function ran."""
         os_path.append("old_post_save")
 
     jupyter_config_obj.FileContentsManager.post_save_hook = old_post_save
 
     def mocked_post_save(model, os_path, contents_manager):
-        """Append a token to os_path to certify that function ran.
-        """
+        """Append a token to os_path to certify that function ran."""
         os_path.append("nbautoexport")
 
     monkeypatch.setattr(nbautoexport_root, "post_save", mocked_post_save)
@@ -264,8 +258,7 @@ def test_initialize_post_save_existing(monkeypatch):
 
 
 def test_initialize_post_save_import_error_caught(monkeypatch):
-    """Test that bound post_save hook with given signature can be successfully run.
-    """
+    """Test that bound post_save hook with given signature can be successfully run."""
 
     jupyter_config_obj = Config(FileContentsManager=FileContentsManager())
 

--- a/tests/test_sentinel.py
+++ b/tests/test_sentinel.py
@@ -5,8 +5,7 @@ from nbautoexport.sentinel import ExportFormat
 
 
 def test_export_format_compatibility():
-    """Test that export formats are compatible with Jupyter nbautoconvert.
-    """
+    """Test that export formats are compatible with Jupyter nbautoconvert."""
     nbconvert_export_names = get_export_names()
     for export_format in ExportFormat:
         assert export_format.value in nbconvert_export_names

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -68,8 +68,7 @@ def test_find_notebooks_warning(tmp_path):
 
 
 def test_cleared_argv(monkeypatch):
-    """cleared_argv context manager clears sys.argv and restores it on exit
-    """
+    """cleared_argv context manager clears sys.argv and restores it on exit"""
     mocked_argv = ["nbautoexport", "convert", "the_notebook.ipynb", "-f", "script"]
     monkeypatch.setattr(sys, "argv", mocked_argv)
 
@@ -82,8 +81,7 @@ def test_cleared_argv(monkeypatch):
 
 
 def test_cleared_argv_with_error(monkeypatch):
-    """cleared_argv context manager restores sys.argv even with exception
-    """
+    """cleared_argv context manager restores sys.argv even with exception"""
     mocked_argv = ["nbautoexport", "convert", "the_notebook.ipynb", "-f", "script"]
     monkeypatch.setattr(sys, "argv", mocked_argv)
 


### PR DESCRIPTION
Adds new `exclude` option to specify glob patterns for excluding files from cleaning. Resolves #46. 

- [x] TODO: Write page about cleaning for docs site
  - New page here: https://deploy-preview-54--zen-roentgen-1e5a72.netlify.app/cleaning/
- [x] TODO: Update HISTORY.md