### PR TITLE
Require nbconvert <6 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 jupyter-contrib-nbextensions>=0.5.1
-nbconvert>=5.6.1
+nbconvert>=5.6.1,<6
 packaging
 pydantic
 typer>=0.3.0


### PR DESCRIPTION
Minor fix to address #57. We can release this as a patch release and address the underlying issue in a minor release later.  