### PR TITLE
Dependency cleanup; post-save test

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,8 +1,12 @@
 # History
 
+## 0.3.1 (Unreleased)
+
+- Remove extraneous dependency on `jupyter_contrib_nbextensions`. Add `traitlets`, `notebook`, `jupyter_core`, and `nbformat` as explicit dependencies; previously they were treated as transitive dependencies even though they are actually direct dependencies. [#68](https://github.com/drivendataorg/nbautoexport/issues/68)
+
 ## 0.3.0 (2021-02-18)
 
-- Explicitly set all input and output file encodings to UTF-8, which fixes a bug with HTML exports on Windows with `nbconvert` v6.0. This version removes the version ceiling on <6. 
+- Explicitly set all input and output file encodings to UTF-8, which fixes a bug with HTML exports on Windows with `nbconvert` v6.0. This version removes the version ceiling on <6.
   - This is not expected to cause any backwards compatibility issues. However, in the _very_ unlikely instance that your `jupyter_notebook_config.py` file or your `nbautoexport.json` config file is Windows-1252-encoded _and_ contains non-ASCII characters, you will need to convert them to UTF-8. ([#57](https://github.com/drivendataorg/nbautoexport/issues/57), [#61](https://github.com/drivendataorg/nbautoexport/pull/61))
 
 ## 0.2.1 (2020-09-18)

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -6,7 +6,7 @@ import textwrap
 from typing import Optional
 
 from jupyter_core.paths import jupyter_config_dir
-from traitlets.config.loader import Config
+from traitlets.config import Config
 
 from nbautoexport.utils import __version__, logger
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,8 @@
-jupyter-contrib-nbextensions>=0.5.1
+jupyter_core
 nbconvert>=5.6.1
+nbformat
+notebook
 packaging
 pydantic
+traitlets
 typer>=0.3.0

--- a/tests/test_post_save.py
+++ b/tests/test_post_save.py
@@ -1,0 +1,83 @@
+import shutil
+
+import nbformat
+from notebook.services.contents.filemanager import FileContentsManager
+import pytest
+from traitlets.config import Config
+
+from nbautoexport.jupyter_config import initialize_post_save_hook
+from nbautoexport.sentinel import (
+    ExportFormat,
+    NbAutoexportConfig,
+    OrganizeBy,
+    SAVE_PROGRESS_INDICATOR_FILE,
+)
+
+
+@pytest.fixture()
+def notebook_file(tmp_path, notebook_asset):
+    nb_file = tmp_path / "the_notebook.ipynb"
+    shutil.copy(notebook_asset.path, nb_file)
+    return nb_file
+
+
+@pytest.fixture()
+def notebook_model(notebook_file):
+    model = {
+        "type": "notebook",
+        "content": nbformat.read(str(notebook_file), as_version=nbformat.NO_CONVERT),
+    }
+    return model
+
+
+@pytest.fixture()
+def file_contents_manager(notebook_file):
+    config = Config(FileContentsManager=FileContentsManager())
+    config.FileContentsManager.root_dir = str(notebook_file.parent)
+    initialize_post_save_hook(config)
+    return config.FileContentsManager
+
+
+def test_post_save(file_contents_manager, notebook_file, notebook_model):
+    """Test that post_save function works when FileContentsManager saves."""
+    config = NbAutoexportConfig(
+        export_formats=[ExportFormat.script], organize_by=OrganizeBy.extension
+    )
+    with (notebook_file.parent / SAVE_PROGRESS_INDICATOR_FILE).open("w", encoding="utf-8") as fp:
+        fp.write(config.json())
+
+    file_contents_manager.save(notebook_model, path=notebook_file.name)
+
+    assert (notebook_file.parent / "script" / f"{notebook_file.stem}.py").exists()
+
+
+def test_not_notebook(file_contents_manager, tmp_path):
+    """Test that post_save function ignores non-notebook file when FileContentsManager saves."""
+    config = NbAutoexportConfig(
+        export_formats=[ExportFormat.script], organize_by=OrganizeBy.extension
+    )
+    with (tmp_path / SAVE_PROGRESS_INDICATOR_FILE).open("w", encoding="utf-8") as fp:
+        fp.write(config.json())
+
+    file_path = tmp_path / "journal.txt"
+    with file_path.open("w", encoding="utf-8") as fp:
+        fp.write("I'm a journal.")
+
+    model = {
+        "type": "file",
+        "format": "text",
+        "mimetype": "text/plain",
+        "content": "I'm a journal.",
+    }
+
+    file_contents_manager.save(model, path=str(file_path.name))
+
+    assert not (tmp_path / "script" / f"{file_path.stem}.py").exists()
+
+
+def test_no_config(file_contents_manager, notebook_file, notebook_model):
+    """Test that post_save function does nothing without nbautoexport config file when
+    FileContentsManager saves."""
+    file_contents_manager.save(notebook_model, path=notebook_file.name)
+
+    assert not (notebook_file.parent / "script" / f"{notebook_file.stem}.py").exists()

--- a/tests/test_post_save.py
+++ b/tests/test_post_save.py
@@ -39,7 +39,8 @@ def file_contents_manager(notebook_file):
 
 
 def test_post_save(file_contents_manager, notebook_file, notebook_model):
-    """Test that post_save function works when FileContentsManager saves."""
+    """Test that post_save function works when FileContentsManager saves based on config file."""
+
     config = NbAutoexportConfig(
         export_formats=[ExportFormat.script], organize_by=OrganizeBy.extension
     )
@@ -49,6 +50,23 @@ def test_post_save(file_contents_manager, notebook_file, notebook_model):
     file_contents_manager.save(notebook_model, path=notebook_file.name)
 
     assert (notebook_file.parent / "script" / f"{notebook_file.stem}.py").exists()
+    assert not (notebook_file.parent / notebook_file.stem / f"{notebook_file.stem}.html").exists()
+
+    # Update config and check that output is different
+
+    (notebook_file.parent / "script" / f"{notebook_file.stem}.py").unlink()
+
+    config = NbAutoexportConfig(
+        export_formats=[ExportFormat.html], organize_by=OrganizeBy.notebook
+    )
+
+    with (notebook_file.parent / SAVE_PROGRESS_INDICATOR_FILE).open("w", encoding="utf-8") as fp:
+        fp.write(config.json())
+
+    file_contents_manager.save(notebook_model, path=notebook_file.name)
+
+    assert not (notebook_file.parent / "script" / f"{notebook_file.stem}.py").exists()
+    assert (notebook_file.parent / notebook_file.stem / f"{notebook_file.stem}.html").exists()
 
 
 def test_not_notebook(file_contents_manager, tmp_path):
@@ -80,4 +98,7 @@ def test_no_config(file_contents_manager, notebook_file, notebook_model):
     FileContentsManager saves."""
     file_contents_manager.save(notebook_model, path=notebook_file.name)
 
-    assert not (notebook_file.parent / "script" / f"{notebook_file.stem}.py").exists()
+    assert set(notebook_file.parent.iterdir()) == {
+        notebook_file.parent / ".ipynb_checkpoints",
+        notebook_file,
+    }


### PR DESCRIPTION
- Remove extraneous dependency on `jupyter_contrib_nbextensions`. Add `traitlets`, `notebook`, `jupyter_core`, and `nbformat` as explicit dependencies; previously they were treated as transitive dependencies even though they are actually direct dependencies. Closes #56. 
- Adds tests for `post_save` by using `FileContentsManager.save`. This is the mechanism by which Jupyter saves files. Closes #5. 
