### PR TITLE
Add missing typing stub packages for mypy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,7 +59,7 @@ install: clean ## install the package to the active Python's site-packages
 lint: ## check style with flake8
 	black --check nbautoexport tests
 	flake8 nbautoexport tests
-	mypy nbautoexport tests
+	mypy --install-types --non-interactive nbautoexport tests
 
 release: dist ## package and upload a release
 	twine upload dist/*


### PR DESCRIPTION
Fixes our failing build. 

~Putting it in `make lint` seems like the most straightforward solution since it's only required for mypy checks. Running it multiple times doesn't seem to add any overheard.~ 

After reading through [this very confusing thread](https://github.com/python/mypy/issues/10600), apparently [this solution](https://github.com/python/mypy/pull/10669) was recently implemented. 