### PR TITLE
Notify failed master build + Versioned docs

### DIFF
--- a/.github/failed_build_issue_template.md
+++ b/.github/failed_build_issue_template.md
@@ -1,0 +1,5 @@
+---
+title: "Failed build on master branch ({{ env.WORKFLOW_NAME}} #{{ env.RUN_NUMBER }})"
+labels: bug
+---
+Workflow failed: [{{ env.WORKFLOW_NAME}} #{{ env.RUN_NUMBER }}](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }})

--- a/.github/workflows/docs-master.yml
+++ b/.github/workflows/docs-master.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and publish docs
+    name: Build from master
     runs-on: "ubuntu-latest"
 
     steps:
@@ -15,22 +15,39 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt --use-feature=2020-resolver
-          pip install -e .
+          pip install -r requirements-dev.txt
 
       - name: Build docs
         run: |
           make docs
 
+      - name: Stage docs on gh-pages
+        working-directory: docs
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          mike deploy --push ~latest --title=latest
+
+  deploy:
+    name: Deploy docs to Netlify
+    needs: build
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
       - name: Deploy docs to Netlify
         uses: nwtgck/actions-netlify@v1.1
         with:
-          publish-dir: "./docs/site"
+          publish-dir: "./"
           production-deploy: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message: "Deploy from GitHub Actions"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,40 +16,29 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements-dev.txt --use-feature=2020-resolver
-          pip install -e .
+          pip install -r requirements-dev.txt
+
+      - name: Check that versions match
+        id: version
+        run: |
+          echo "Release tag: [${{ github.event.release.tag_name }}]"
+          PACKAGE_VERSION=$(nbautoexport --version)
+          echo "Package version: [$PACKAGE_VERSION]"
+          [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
+          echo "::set-output name=major_minor_version::v${PACKAGE_VERSION%.*}"
 
       - name: Build package
         run: |
-          echo "${{ github.event.release.tag_name }}"
-          PACKAGE_VERSION=$(nbautoexport --version)
-          echo $PACKAGE_VERSION
-          [ ${{ github.event.release.tag_name }} == "v$PACKAGE_VERSION" ] || { exit 1; }
           make dist
 
       - name: Build docs
         run: |
           make docs
-
-      - name: Deploy docs to Netlify
-        uses: nwtgck/actions-netlify@v1.1
-        with:
-          publish-dir: "./docs/site"
-          production-deploy: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          deploy-message: "Deploy from GitHub Actions"
-          enable-pull-request-comment: false
-          enable-commit-comment: false
-          overwrites-pull-request-comment: false
-        env:
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-        timeout-minutes: 1
 
       - name: Publish to Test PyPI
         uses: pypa/gh-action-pypi-publish@v1.3.0
@@ -65,3 +54,45 @@ jobs:
           user: ${{ secrets.PYPI_PROD_USERNAME }}
           password: ${{ secrets.PYPI_PROD_PASSWORD }}
           skip_existing: false
+
+      - name: Stage docs on gh-pages
+        working-directory: docs
+        run: |
+          git fetch origin gh-pages --depth=1
+          git config user.name github-actions[bot]
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          # Rename old stable version
+          mike list -j | jq
+          OLD_STABLE=$(mike list -j | jq -r '.[] | select(.aliases | index("stable")) | .title' | awk '{print $1;}')
+          echo $OLD_STABLE
+          mike retitle stable $OLD_STABLE
+          # Deploy new version as stable
+          mike deploy --push --update-aliases --no-redirect \
+            ${{ steps.version.outputs.major_minor_version }} \
+            stable \
+            --title="${{ github.event.release.tag_name }} (stable)"
+
+  deploy-docs:
+    name: Deploy docs to Netlify
+    needs: build
+    runs-on: "ubuntu-latest"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: gh-pages
+
+      - name: Deploy docs to Netlify
+        uses: nwtgck/actions-netlify@v1.1
+        with:
+          publish-dir: "./"
+          production-deploy: true
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          deploy-message: "Deploy from GitHub Actions"
+          enable-pull-request-comment: false
+          enable-commit-comment: false
+          overwrites-pull-request-comment: false
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        timeout-minutes: 1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     # Run every Sunday
     - cron: "0 0 * * 0"
+  workflow_dispatch:
 
 jobs:
   code-quality:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,13 +9,45 @@ on:
     - cron: "0 0 * * 0"
 
 jobs:
-  build:
-    name: ${{ matrix.os }}, Python ${{ matrix.python-version }}
+  code-quality:
+    name: Code Quality
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python with Miniconda
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          python-version: 3.8
+          channels: conda-forge
+
+      - name: Install dependencies
+        run: |
+          which python
+          python --version
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements-dev.txt
+          conda install pandoc
+
+      - name: Lint package
+        run: |
+          make lint
+
+  tests:
+    name: Tests (${{ matrix.os }}, Python ${{ matrix.python-version }})
+    needs: code-quality
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: [3.6, 3.7, 3.8]
+    defaults:
+      run:
+        shell: bash -l {0}
 
     steps:
       - uses: actions/checkout@v2
@@ -27,7 +59,6 @@ jobs:
           channels: conda-forge
 
       - name: Install dependencies
-        shell: bash -l {0}
         run: |
           which python
           python --version
@@ -35,31 +66,27 @@ jobs:
           python -m pip install -r requirements-dev.txt --use-feature=2020-resolver
           conda install pandoc
 
-      - name: Lint package
-        shell: bash -l {0}
-        run: |
-          make lint
-
       - name: Run tests
-        shell: bash -l {0}
         run: |
           make test
 
       - name: Build distribution and test installation
-        shell: bash -l {0}
         run: |
           make dist
           python -m pip install dist/nbautoexport-*.whl --no-deps --force-reinstall
+          nbautoexport --version
           python -m pip install dist/nbautoexport-*.tar.gz --no-deps --force-reinstall
+          nbautoexport --version
 
       - name: Test building documentation
-        shell: bash -l {0}
         run: |
           make docs
         if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
 
       - name: Deploy site preview to Netlify
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+        if: |
+          matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+          && github.event.pull_request != null
         uses: nwtgck/actions-netlify@v1.1
         with:
           publish-dir: "./docs/site"
@@ -80,4 +107,21 @@ jobs:
         with:
           file: ./coverage.xml
           fail_ci_if_error: true
-        if: matrix.os == 'ubuntu-latest' && matrix.python-version == 3.8
+        if: matrix.os == 'ubuntu-latest'
+
+  notify:
+    name: Notify failed build
+    needs: [code-quality, tests]
+    if: failure() && github.event.pull_request == null
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          WORKFLOW_NAME: ${{ github.workflow }}
+          RUN_NUMBER: ${{ github.run_number}}
+          REPOSITORY: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+        with:
+          filename: .github/failed_build_issue_template.md

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # nbautoexport
 
-[![Docs Status](https://img.shields.io/badge/docs-latest-blueviolet)](https://nbautoexport.drivendata.org/)
+[![Docs Status](https://img.shields.io/badge/docs-stable-informational)](https://nbautoexport.drivendata.org/)
 [![PyPI](https://img.shields.io/pypi/v/nbautoexport.svg)](https://pypi.org/project/nbautoexport/)
 [![conda-forge](https://img.shields.io/conda/vn/conda-forge/nbautoexport.svg)](https://anaconda.org/conda-forge/nbautoexport)
 [![tests](https://github.com/drivendataorg/nbautoexport/workflows/tests/badge.svg?branch=master)](https://github.com/drivendataorg/nbautoexport/actions?query=workflow%3Atests+branch%3Amaster)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -31,3 +31,7 @@ plugins:
             heading_level: 2
       watch:
         - nbautoexport
+
+extra:
+  version:
+    provider: mike

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,13 +1,11 @@
--c requirements.txt
--r requirements.txt
-
 -e .
 
 black>=19.3b0
 coverage>=4.5.4
 flake8>=3.7.8
-mkdocs>=1.1
-mkdocs-material
+mike
+mkdocs>=1.2.2
+mkdocs-material>=7.2.6
 mkdocstrings
 mypy>=0.782
 pip>=19.2.3


### PR DESCRIPTION
## Test workflow improvements

  - Splits code quality check (linting) into a separate workflow job that runs before tests. If code quality fails, tests do not run.
  - Add a workflow job that opens an issue if any previous job fails for non-PR workflows.
  - Add `workflow_dispatch` trigger which enables manually triggering workflow in GitHub UI

## Versioned docs using CI 

- `docs-master` will publish to `latest` version on any merges to master
- `release` workflow will publish and overwrite any previous docs with same `<major>.<minor>` version. The new version will also be tagged with `(stable)` and is assigned the alias `stable`.

We use `latest` and `stable` to refer to master branch and current release, respectively, per Read the Docs naming convention. I've also updated the README badge to say "stable" instead of "latest". 

All docs are stored on the `gh-pages` branch, and the workflows will push that branch to Netlify. I've manually backfilled existing releases. This won't be pushed to Netlify until the PR is merged. In the meantime, you can see https://erdantic.drivendata.org/ as an example. 

PR previews continue to work as-is without integration with the other versions. 
