### PR TITLE
Update tests for typer 0.4.0 and click 8

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,15 +6,15 @@ from nbautoexport.nbautoexport import app
 from nbautoexport import __version__
 
 
-def test_main():
-    """Test the CLI main callback."""
+def test_no_command():
+    """Test the CLI errors with no command."""
     runner = CliRunner()
     result = runner.invoke(app)
-    assert result.exit_code == 0
-    assert "Automatically export Jupyter notebooks to various file formats" in result.output
+    assert result.exit_code > 0
+    assert "Error: Missing command." in result.output
 
 
-def test_main_help():
+def test_help():
     """Test the CLI main callback with --help flag."""
     runner = CliRunner()
     result = runner.invoke(app, ["--help"])
@@ -30,17 +30,18 @@ def test_version():
     assert result.output.strip() == __version__
 
 
-def test_main_python_m():
+def test_no_command_python_m():
+    """Test the CLI with python -m errors with no command."""
     result = subprocess.run(
         ["python", "-m", "nbautoexport"],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         universal_newlines=True,
     )
-    assert result.returncode == 0
-    assert "Automatically export Jupyter notebooks to various file formats" in result.stdout
-    assert result.stdout.startswith("Usage: python -m nbautoexport")
-    assert "Usage: __main__.py" not in result.stdout
+    assert result.returncode > 0
+    assert "Error: Missing command." in result.stderr
+    assert result.stderr.startswith("Usage: python -m nbautoexport")
+    assert "Usage: __main__.py" not in result.stderr
 
 
 def test_version_python_m():

--- a/tests/test_cli_configure.py
+++ b/tests/test_cli_configure.py
@@ -64,20 +64,16 @@ def test_invalid_export_format():
     runner = CliRunner()
     result = runner.invoke(app, ["configure", "-f", "invalid-output-format"])
     assert result.exit_code == 2
-    assert (
-        "Error: Invalid value for '--export-format' / '-f': invalid choice: invalid-output-format"
-        in result.output
-    )
+    assert "Error: Invalid value for '--export-format' / '-f'" in result.output
+    assert "invalid-output-format" in result.output
 
 
 def test_invalid_organize_by():
     runner = CliRunner()
     result = runner.invoke(app, ["configure", "-b", "invalid-organize-by"])
     assert result.exit_code == 2
-    assert (
-        "Invalid value for '--organize-by' / '-b': invalid choice: invalid-organize-by"
-        in result.output
-    )
+    assert "Invalid value for '--organize-by' / '-b'" in result.output
+    assert "invalid-organize-by" in result.output
 
 
 def test_refuse_overwrite(tmp_path):


### PR DESCRIPTION
Recently typer released 0.4.0, which also increases the version ceiling of click to include click 8. This has some changes to behavior that broke some of our tests:

-  Calling `nbautoexport` without any commands now errors with code 2 instead of succeeding. 
    - This is probably a good change because running this command doesn't successfully do anything. 
    - It no longer prints the help text anymore, which is maybe less desirable. I opened https://github.com/tiangolo/typer/issues/328 on tiangolo/typer about this. 
- Invalid option values had their error message slightly changed. This updates our asserts to work with the new error text.
    - Before: `"Invalid value for '--organize-by' / '-b': invalid choice: invalid-organize-by"`
    - After: `Invalid value for '--organize-by' / '-b': 'foo' is not one of 'notebook', 'extension'.`

Fixes #76 