### PR TITLE
Improve logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@ docs/docs/index.md
 docs/docs/changelog.md
 docs/docs/command-reference/*.md
 
+# Ignore notebooks directory used for manual testing
+notebooks/
+
 ## GitHub Python .gitignore ##
 # https://github.com/github/gitignore/blob/master/Python.gitignore
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -4,6 +4,7 @@
 
 - Logging improvements. ([Issue #74](https://github.com/drivendataorg/nbautoexport/issues/74), [PR #80](https://github.com/drivendataorg/nbautoexport/pull/80))
   - Adds additional log statements during post-save hook initialization and execution to facilitate debugging.
+  - Changes runtime errors in post-save hook to be caught gracefully instead of interrupting user with an alert dialog in the Jupyter UI.
   - Adds logging integration with active Jupyter applications. Logs will use Jupyter formatting.
   - Changes `--verbose`/`-v` flag to work as a counter. `-v` will set log level to INFO, and `-vv` will set log level to `DEBUG`.
 

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,12 @@
 # History
 
+## 0.4.0 (unreleased)
+
+- Logging improvements. ([Issue #74](https://github.com/drivendataorg/nbautoexport/issues/74), [PR #80](https://github.com/drivendataorg/nbautoexport/pull/80))
+  - Adds additional log statements during post-save hook initialization and execution to facilitate debugging.
+  - Adds logging integration with active Jupyter applications. Logs will use Jupyter formatting.
+  - Changes `--verbose`/`-v` flag to work as a counter. `-v` will set log level to INFO, and `-vv` will set log level to `DEBUG`.
+
 ## 0.3.1 (2021-03-10)
 
 - Remove extraneous dependency on `jupyter_contrib_nbextensions`. Add `traitlets`, `notebook`, `jupyter_core`, and `nbformat` as explicit dependencies; previously they were treated as transitive dependencies even though they are actually direct dependencies. [#68](https://github.com/drivendataorg/nbautoexport/issues/68)

--- a/nbautoexport/__init__.py
+++ b/nbautoexport/__init__.py
@@ -1,4 +1,8 @@
 from nbautoexport.export import post_save
-from nbautoexport.utils import __version__
+from nbautoexport.utils import __version__, get_logger
 
-__all__ = [post_save, __version__]
+__all__ = [
+    "post_save",
+    "get_logger",
+]
+__version__

--- a/nbautoexport/export.py
+++ b/nbautoexport/export.py
@@ -70,6 +70,7 @@ def post_save(model: dict, os_path: str, contents_manager: FileContentsManager):
         os_path (str): the filesystem path to the file just written
         contents_manager (FileContentsManager): FileContentsManager instance that hook is bound to
     """
+    logger.debug("nbautoexport | Executing nbautoexport.export.post_save ...")
     # only do this for notebooks
     if model["type"] != "notebook":
         logger.debug(f"nbautoexport | {os_path} is not a notebook. Nothing to do.")
@@ -79,6 +80,9 @@ def post_save(model: dict, os_path: str, contents_manager: FileContentsManager):
     os_path = Path(os_path)
     cwd = os_path.parent
     save_progress_indicator = cwd / SAVE_PROGRESS_INDICATOR_FILE
+    logger.debug(
+        f"nbautoexport | Looking for config file {save_progress_indicator} ...",
+    )
     should_convert = save_progress_indicator.exists()
 
     if should_convert:
@@ -92,6 +96,7 @@ def post_save(model: dict, os_path: str, contents_manager: FileContentsManager):
             logger.error(f"nbautoexport | {type(e).__name__}: {e}")
     else:
         logger.debug(f"nbautoexport | {save_progress_indicator} not found. Nothing to do.")
+    logger.debug("nbautoexport | post_save done.")
 
 
 def export_notebook(notebook_path: Path, config: NbAutoexportConfig):
@@ -101,6 +106,7 @@ def export_notebook(notebook_path: Path, config: NbAutoexportConfig):
         notebook_path (Path): path to notebook to export with nbconvert
         config (NbAutoexportConfig): configuration
     """
+    logger.debug(f"nbautoexport | Exporting notebook with configuration:\n{config.json(indent=2)}")
     with cleared_argv():
         converter = NbConvertApp()
 

--- a/nbautoexport/export.py
+++ b/nbautoexport/export.py
@@ -86,7 +86,7 @@ def post_save(model: dict, os_path: str, contents_manager: FileContentsManager):
     should_convert = save_progress_indicator.exists()
 
     if should_convert:
-        logger.info(f"nbautoexport | Exporting {os_path.relative_to(Path())} ...")
+        logger.info(f"nbautoexport | Exporting {os_path} ...")
         try:
             config = NbAutoexportConfig.parse_file(
                 path=save_progress_indicator, content_type="application/json", encoding="utf-8"

--- a/nbautoexport/export.py
+++ b/nbautoexport/export.py
@@ -78,8 +78,8 @@ def post_save(model: dict, os_path: str, contents_manager: FileContentsManager):
             return
 
         # only do this if we've added the special indicator file to the working directory
-        os_path = Path(os_path)
-        cwd = os_path.parent
+        notebook_path = Path(os_path)
+        cwd = notebook_path.parent
         save_progress_indicator = cwd / SAVE_PROGRESS_INDICATOR_FILE
         should_convert = save_progress_indicator.exists()
 
@@ -88,7 +88,7 @@ def post_save(model: dict, os_path: str, contents_manager: FileContentsManager):
             config = NbAutoexportConfig.parse_file(
                 path=save_progress_indicator, content_type="application/json", encoding="utf-8"
             )
-            export_notebook(os_path, config=config)
+            export_notebook(notebook_path, config=config)
 
         else:
             logger.debug(f"nbautoexport | {save_progress_indicator} not found. Nothing to do.")

--- a/nbautoexport/export.py
+++ b/nbautoexport/export.py
@@ -109,6 +109,7 @@ def export_notebook(notebook_path: Path, config: NbAutoexportConfig):
     logger.debug(f"nbautoexport | Exporting notebook with configuration:\n{config.json(indent=2)}")
     with cleared_argv():
         converter = NbConvertApp()
+        converter.log.handlers = logger.handlers
 
         for export_format in config.export_formats:
             if config.organize_by == "notebook":

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -43,9 +43,9 @@ def initialize_post_save_hook(c: Config):
     except Exception as e:
         msg = f"nbautoexport | Failed to register post-save hook due to {type(e).__name__}: {e}"
         try:
-            from traitlets.log import get_logger
+            import traitlets.config.application
 
-            get_logger().error(msg)
+            traitlets.config.application.Application.instance().log.error(msg)
         except Exception as e2:
             print(
                 "nbautoexport | Failed to load traitlets application logger due to "

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -8,7 +8,10 @@ from typing import Optional
 from jupyter_core.paths import jupyter_config_dir
 from traitlets.config import Config
 
-from nbautoexport.utils import __version__, logger
+from nbautoexport.utils import __version__, get_logger
+
+
+logger = get_logger()
 
 
 def initialize_post_save_hook(c: Config):

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -15,7 +15,7 @@ logger = get_logger()
 
 
 def initialize_post_save_hook(c: Config):
-    # >>> nbautoexport initialize, version=[{version}] >>>
+    # >>> nbautoexport initialize, version=[{{version}}] >>>
     try:
         import nbautoexport
 
@@ -57,7 +57,9 @@ def initialize_post_save_hook(c: Config):
 
 
 post_save_hook_initialize_block = textwrap.dedent(
-    "".join(getsourcelines(initialize_post_save_hook)[0][1:-1]).format(version=__version__)
+    "".join(getsourcelines(initialize_post_save_hook)[0][1:-1]).replace(
+        r"{{version}}", __version__, 1
+    )
 )
 
 block_regex = re.compile(

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -108,7 +108,10 @@ def install_post_save_hook(config_path: Optional[Path] = None):
             logger.info(f"Updating nbautoexport post-save hook with version {__version__}...")
             with config_path.open("w", encoding="utf-8") as fp:
                 # Open as w replaces existing file. We're replacing entire config.
-                fp.write(block_regex.sub(post_save_hook_initialize_block, config))
+                escaped_init = post_save_hook_initialize_block.replace(
+                    "\\", r"\\"
+                )  # escape metachars
+                fp.write(block_regex.sub(escaped_init, config))
         else:
             logger.debug("No changes made.")
             return

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -94,7 +94,7 @@ def install_post_save_hook(config_path: Optional[Path] = None):
         config = fp.read()
 
     if block_regex.search(config):
-        logger.debug("Detected existing nbautoexport post-save hook.")
+        logger.info("Detected existing nbautoexport post-save hook.")
 
         version_match = version_regex.search(config)
         if version_match:
@@ -113,7 +113,7 @@ def install_post_save_hook(config_path: Optional[Path] = None):
                 )  # escape metachars
                 fp.write(block_regex.sub(escaped_init, config))
         else:
-            logger.debug("No changes made.")
+            logger.info("No changes made.")
             return
     else:
         logger.info("Installing post-save hook.")

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -47,11 +47,13 @@ def initialize_post_save_hook(c: Config):
 
             jupyter_core.application.JupyterApp.instance().log.error(msg)
         except Exception as e2:
-            print(
+            import sys
+
+            sys.stderr.write(
                 "nbautoexport | Failed to load JupyterApp logger due to "
-                f"{type(e2).__name__}: {e2}"
+                f"{type(e2).__name__}: {e2}\n"
             )
-            print(msg)
+            sys.stderr.write(msg + "\n")
     # <<< nbautoexport initialize <<<
     pass  # need this line for above comment to be included in function source
 

--- a/nbautoexport/jupyter_config.py
+++ b/nbautoexport/jupyter_config.py
@@ -43,12 +43,12 @@ def initialize_post_save_hook(c: Config):
     except Exception as e:
         msg = f"nbautoexport | Failed to register post-save hook due to {type(e).__name__}: {e}"
         try:
-            import traitlets.config.application
+            import jupyter_core.application
 
-            traitlets.config.application.Application.instance().log.error(msg)
+            jupyter_core.application.JupyterApp.instance().log.error(msg)
         except Exception as e2:
             print(
-                "nbautoexport | Failed to load traitlets application logger due to "
+                "nbautoexport | Failed to load JupyterApp logger due to "
                 f"{type(e2).__name__}: {e2}"
             )
             print(msg)

--- a/nbautoexport/nbautoexport.py
+++ b/nbautoexport/nbautoexport.py
@@ -32,6 +32,7 @@ def validate_sentinel_path(path: Path):
 
 
 def verbose_callback(value: int):
+    """Set up logger with level based on --verbose count."""
     log_handler = logging.StreamHandler()
     logger.addHandler(log_handler)
     log_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
@@ -48,7 +49,7 @@ verbose_option = typer.Option(
     "-v",
     count=True,
     show_default=False,
-    help="Use multiple times to set verbosity/log level. [0 = WARNING, 1 = INFO, 2 = DEBUG]",
+    help="Use multiple times to set verbosity/log level. [-v = INFO, -vv = DEBUG]",
     callback=verbose_callback,
 )
 

--- a/nbautoexport/nbautoexport.py
+++ b/nbautoexport/nbautoexport.py
@@ -19,9 +19,16 @@ from nbautoexport.sentinel import (
     OrganizeBy,
     SAVE_PROGRESS_INDICATOR_FILE,
 )
-from nbautoexport.utils import __version__, find_notebooks
+from nbautoexport.utils import __version__, find_notebooks, get_logger
 
 app = typer.Typer()
+
+# Set up a logger for CLI
+logger = get_logger()
+log_handler = logging.StreamHandler()
+logger.addHandler(log_handler)
+log_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+log_handler.setFormatter(log_formatter)
 
 
 def validate_sentinel_path(path: Path):
@@ -323,7 +330,7 @@ def configure(
     independently configure other directories containing notebooks.
     """
     if verbose:
-        logging.basicConfig(level=logging.DEBUG)
+        logger.setLevel(logging.DEBUG)
 
     config = NbAutoexportConfig(
         export_formats=export_formats,

--- a/nbautoexport/nbautoexport.py
+++ b/nbautoexport/nbautoexport.py
@@ -22,13 +22,7 @@ from nbautoexport.sentinel import (
 from nbautoexport.utils import __version__, find_notebooks, get_logger
 
 app = typer.Typer()
-
-# Set up a logger for CLI
 logger = get_logger()
-log_handler = logging.StreamHandler()
-logger.addHandler(log_handler)
-log_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
-log_handler.setFormatter(log_formatter)
 
 
 def validate_sentinel_path(path: Path):
@@ -38,6 +32,10 @@ def validate_sentinel_path(path: Path):
 
 
 def verbose_callback(value: int):
+    log_handler = logging.StreamHandler()
+    logger.addHandler(log_handler)
+    log_formatter = logging.Formatter("%(asctime)s - %(name)s - %(levelname)s - %(message)s")
+    log_handler.setFormatter(log_formatter)
     if value >= 2:
         logger.setLevel(logging.DEBUG)
     elif value == 1:

--- a/nbautoexport/sentinel.py
+++ b/nbautoexport/sentinel.py
@@ -4,7 +4,10 @@ from typing import List
 
 from pydantic import BaseModel
 
-from nbautoexport.utils import logger
+from nbautoexport.utils import get_logger
+
+
+logger = get_logger()
 
 
 SAVE_PROGRESS_INDICATOR_FILE = ".nbautoexport"

--- a/nbautoexport/utils.py
+++ b/nbautoexport/utils.py
@@ -9,8 +9,7 @@ from warnings import warn
 from pydantic import BaseModel
 from nbconvert.exporters import get_export_names, get_exporter
 import nbformat
-import traitlets.log
-import traitlets.config
+from jupyter_core.application import JupyterApp
 
 from nbautoexport._version import get_versions
 
@@ -19,8 +18,8 @@ __version__ = get_versions()["version"]
 
 
 def get_logger():
-    if traitlets.config.Application.initialized():
-        return traitlets.config.Application.instance().log
+    if JupyterApp.initialized():
+        return JupyterApp.instance().log
     else:
         logger = logging.getLogger("nbautoexport")
         logger.addHandler(logging.NullHandler())

--- a/nbautoexport/utils.py
+++ b/nbautoexport/utils.py
@@ -20,7 +20,7 @@ __version__ = get_versions()["version"]
 
 def get_logger():
     if traitlets.config.Application.initialized():
-        return traitlets.log.get_logger()
+        return traitlets.config.Application.instance().log
     else:
         logger = logging.getLogger("nbautoexport")
         logger.addHandler(logging.NullHandler())

--- a/nbautoexport/utils.py
+++ b/nbautoexport/utils.py
@@ -9,11 +9,22 @@ from warnings import warn
 from pydantic import BaseModel
 from nbconvert.exporters import get_export_names, get_exporter
 import nbformat
+import traitlets.log
+import traitlets.config
 
 from nbautoexport._version import get_versions
 
-logger = logging.getLogger("nbautoexport")
+
 __version__ = get_versions()["version"]
+
+
+def get_logger():
+    if traitlets.config.Application.initialized():
+        return traitlets.log.get_logger()
+    else:
+        logger = logging.getLogger("nbautoexport")
+        logger.addHandler(logging.NullHandler())
+        return logger
 
 
 class JupyterNotebook(BaseModel):

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ allow_redefinition = True
 ignore_errors = True
 
 [tool:pytest]
-collect_ignore = ['setup.py']
 testpaths = tests
 addopts = --cov=. --cov-report=term --cov-report=html --cov-report=xml
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 
+from jupyter_core.application import JupyterApp
 import pytest
-from nbautoexport.utils import cleared_argv, JupyterNotebook
-from traitlets.config.application import Application
+
+from nbautoexport.utils import JupyterNotebook
 
 
 @pytest.fixture(scope="session")
@@ -10,16 +11,10 @@ def notebook_asset():
     return JupyterNotebook.from_file(Path(__file__).parent / "assets" / "the_notebook.ipynb")
 
 
-class MockJupyterApp(Application):
-    pass
-
-
 @pytest.fixture
-def mock_jupyter_app(caplog):
-    """Traitlets application that mocks an active Jupyter server."""
-    with cleared_argv():
-        MockJupyterApp.launch_instance()
-    app = MockJupyterApp.instance()
+def jupyter_app(caplog):
+    """Initialized (but unlaunched) Jupyter app."""
+    app = JupyterApp.instance()
     app.log.addHandler(caplog.handler)
     yield app
     app.log.removeHandler(caplog.handler)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,26 @@
 from pathlib import Path
 
 import pytest
-from nbautoexport.utils import JupyterNotebook
+from nbautoexport.utils import cleared_argv, JupyterNotebook
+from traitlets.config.application import Application
 
 
 @pytest.fixture(scope="session")
 def notebook_asset():
     return JupyterNotebook.from_file(Path(__file__).parent / "assets" / "the_notebook.ipynb")
+
+
+class MockJupyterApp(Application):
+    pass
+
+
+@pytest.fixture
+def mock_jupyter_app(caplog):
+    """Traitlets application that mocks an active Jupyter server."""
+    with cleared_argv():
+        MockJupyterApp.launch_instance()
+    app = MockJupyterApp.instance()
+    app.log.addHandler(caplog.handler)
+    yield app
+    app.log.removeHandler(caplog.handler)
+    app.clear_instance()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+import logging
+import shutil
 import subprocess
 
 from typer.testing import CliRunner
@@ -53,3 +55,36 @@ def test_version_python_m():
     )
     assert result.returncode == 0
     assert result.stdout.strip() == __version__
+
+
+def test_verbose0(notebook_asset, tmp_path, caplog):
+    notebook_path = tmp_path / "the_notebook.ipynb"
+    shutil.copy(notebook_asset.path, notebook_path)
+
+    result = CliRunner().invoke(app, ["export", str(notebook_path)])
+    print(result.stdout)
+    assert all(record[1] >= logging.WARNING for record in caplog.record_tuples)
+    assert "INFO" not in result.stdout
+    assert "DEBUG" not in result.stdout
+
+
+def test_verbose1(notebook_asset, tmp_path, caplog):
+    notebook_path = tmp_path / "the_notebook.ipynb"
+    shutil.copy(notebook_asset.path, notebook_path)
+
+    result = CliRunner().invoke(app, ["export", str(notebook_path), "-v"])
+    print(result.stdout)
+    assert "INFO" in result.stdout
+    assert "DEBUG" not in result.stdout
+    assert all(record[1] >= logging.INFO for record in caplog.record_tuples)
+
+
+def test_verbose2(notebook_asset, tmp_path, caplog):
+    notebook_path = tmp_path / "the_notebook.ipynb"
+    shutil.copy(notebook_asset.path, notebook_path)
+
+    result = CliRunner().invoke(app, ["export", str(notebook_path), "-vv"])
+    print(result.stdout)
+    assert "INFO" in result.stdout
+    assert "DEBUG" in result.stdout
+    assert all(record[1] >= logging.DEBUG for record in caplog.record_tuples)

--- a/tests/test_cli_configure.py
+++ b/tests/test_cli_configure.py
@@ -125,6 +125,9 @@ def test_configure_oudated_initialize_warning(tmp_path, monkeypatch):
             "0", jupyter_config.post_save_hook_initialize_block
         )
         fp.write(initialize_block)
+    # Print to assist with debugging
+    with jupyter_config_path.open("r") as fp:
+        print(fp.read())
 
     result = CliRunner().invoke(app, ["configure", str(tmp_path)])
     assert result.exit_code == 0
@@ -134,7 +137,11 @@ def test_configure_oudated_initialize_warning(tmp_path, monkeypatch):
 def test_configure_no_warning(tmp_path, monkeypatch):
     monkeypatch.setenv("JUPYTER_CONFIG_DIR", str(tmp_path))
 
-    jupyter_config.install_post_save_hook(tmp_path / "jupyter_notebook_config.py")
+    jupyter_config_path = tmp_path / "jupyter_notebook_config.py"
+    jupyter_config.install_post_save_hook(jupyter_config_path)
+    # Print to assist with debugging
+    with jupyter_config_path.open("r") as fp:
+        print(fp.read())
 
     result = CliRunner().invoke(app, ["configure", str(tmp_path)])
     assert result.exit_code == 0

--- a/tests/test_jupyter_config.py
+++ b/tests/test_jupyter_config.py
@@ -214,9 +214,9 @@ def test_initialize_post_save_binding():
     assert jupyter_config_obj.FileContentsManager.post_save_hook is export.post_save
 
 
-def test_initialize_post_save_execution(monkeypatch, caplog, mock_jupyter_app):
+def test_initialize_post_save_execution(monkeypatch, caplog):
     """Test that post_save initialization works as expected and bound post_save executes."""
-    caplog.set_level(logging.DEBUG, logger=mock_jupyter_app.log.name)
+    caplog.set_level(logging.DEBUG)
 
     jupyter_config_obj = Config(FileContentsManager=FileContentsManager())
 
@@ -231,7 +231,6 @@ def test_initialize_post_save_execution(monkeypatch, caplog, mock_jupyter_app):
 
     assert caplog_contains(
         caplog,
-        name=mock_jupyter_app.log.name,
         level=logging.INFO,
         in_msg="nbautoexport | Successfully registered post-save hook",
     )
@@ -244,9 +243,9 @@ def test_initialize_post_save_execution(monkeypatch, caplog, mock_jupyter_app):
     assert os_path_list == ["nbautoexport"]
 
 
-def test_initialize_post_save_existing(monkeypatch, caplog, mock_jupyter_app):
+def test_initialize_post_save_existing(monkeypatch, caplog):
     """Test that handling of existing post_save hook works properly."""
-    caplog.set_level(logging.DEBUG, logger=mock_jupyter_app.log.name)
+    caplog.set_level(logging.DEBUG)
 
     jupyter_config_obj = Config(FileContentsManager=FileContentsManager())
 
@@ -267,13 +266,11 @@ def test_initialize_post_save_existing(monkeypatch, caplog, mock_jupyter_app):
 
     assert caplog_contains(
         caplog,
-        name=mock_jupyter_app.log.name,
         level=logging.INFO,
         in_msg="nbautoexport | Existing post_save_hook found",
     )
     assert caplog_contains(
         caplog,
-        name=mock_jupyter_app.log.name,
         level=logging.INFO,
         in_msg="nbautoexport | Successfully registered post-save hook",
     )
@@ -286,7 +283,7 @@ def test_initialize_post_save_existing(monkeypatch, caplog, mock_jupyter_app):
     assert os_path_list == ["old_post_save", "nbautoexport"]
 
 
-def test_initialize_post_save_import_error_caught(monkeypatch, caplog, mock_jupyter_app):
+def test_initialize_post_save_import_error_caught(monkeypatch, caplog, jupyter_app):
     """Test that missing nbautoexport error is caught and properly logged."""
 
     real_import = __builtins__["__import__"]
@@ -309,7 +306,7 @@ def test_initialize_post_save_import_error_caught(monkeypatch, caplog, mock_jupy
 
     assert caplog_contains(
         caplog,
-        name=mock_jupyter_app.log.name,
+        name=jupyter_app.log.name,
         level=logging.ERROR,
         in_msg="ModuleNotFoundError: No module named 'nbautoexport'",
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,7 +6,25 @@ import sys
 import pytest
 
 from nbautoexport.sentinel import NbAutoexportConfig, SAVE_PROGRESS_INDICATOR_FILE
-from nbautoexport.utils import JupyterNotebook, cleared_argv, find_notebooks, working_directory
+from nbautoexport.utils import (
+    JupyterNotebook,
+    cleared_argv,
+    find_notebooks,
+    get_logger,
+    working_directory,
+)
+
+
+def test_get_logger_jupyter_app(mock_jupyter_app):
+    """Test that get_logger() returns Jupyter app's logger if one is active."""
+    logger = get_logger()
+    assert logger is mock_jupyter_app.log
+
+
+def test_get_logger_no_jupyter_app():
+    """Test that get_logger() returns 'nbautoexport' logger if no Jupyter app is active."""
+    logger = get_logger()
+    assert logger.name == "nbautoexport"
 
 
 def test_get_script_extensions(notebook_asset, monkeypatch):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from pathlib import Path
 import shutil
 import sys
@@ -15,15 +16,17 @@ from nbautoexport.utils import (
 )
 
 
-def test_get_logger_jupyter_app(mock_jupyter_app):
+def test_get_logger_jupyter_app(jupyter_app):
     """Test that get_logger() returns Jupyter app's logger if one is active."""
     logger = get_logger()
-    assert logger is mock_jupyter_app.log
+    assert isinstance(logger, logging.Logger)
+    assert logger is jupyter_app.log
 
 
 def test_get_logger_no_jupyter_app():
     """Test that get_logger() returns 'nbautoexport' logger if no Jupyter app is active."""
     logger = get_logger()
+    assert isinstance(logger, logging.Logger)
     assert logger.name == "nbautoexport"
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,19 @@
+from typing import Optional
+
+import pytest
+
+
+def caplog_contains(
+    caplog: pytest.LogCaptureFixture,
+    name: Optional[str] = None,
+    level: Optional[int] = None,
+    in_msg: Optional[str] = None,
+):
+    """Utility function to check whether caplog's records contain a particular log."""
+    for record_tuple in caplog.record_tuples:
+        name_match = name is None or record_tuple[0] == name
+        level_match = level is None or record_tuple[1] == level
+        in_msg_match = in_msg is None or in_msg in record_tuple[2]
+        if name_match and level_match and in_msg_match:
+            return True
+    return False


### PR DESCRIPTION
Improves logging for nbautoexport to make things easier to troubleshoot.

There are three scenarios of use, each of which will have logging that works differently, in order of likely relevance to users:

1. **Running with Jupyter app.** The logger is set to the Jupyter server logger, which we grab via a traitlets convenience method. This will log things with consistent formatting as the rest of Jupyter's logs with pretty colors. 
2. **Using nbautoexport CLI.** The logger named `"nbautoexport"` is used, and configured with a stream handler that will print to console. The `--verbose/-v` flag is now a counter instead of a boolean flag. 
    - Default will print `typer.echo` statements and sets log level to WARNING.
    - `-v` is INFO log level. 
    - `-vv` is DEBUG log level.
3. **Importing as library.** (This isn't something users will likely do, but it is possible so this is implemented for completeness.) The logger named `"nbautoexport"` is used, and set with a null handler. This is [best practice](https://docs.python.org/3/howto/logging.html#library-config) so that the nbautoexport logger will inherit the users' desired configuration from the root logger. 

One change looking for feedback:
- Before: Runtime error in post-save hook (e.g., if .nbautoexport config is invalid) would fail loudly (popup in Jupyter UI, see [example](https://user-images.githubusercontent.com/2721979/134002315-4ca9525d-9ff1-415c-b641-b9485c39249e.png))
- After: Will not do anything in Jupyter UI but will still log error to the server logs

---

## Examples of logs from Jupyter Lab

### Successful startup

#### Jupyter Lab
<img width="706" alt="startup_success" src="https://user-images.githubusercontent.com/2721979/133942188-a6be90aa-9e3c-4f9c-9811-e874b42ae447.png">

#### Jupyter Notebook
<img width="658" alt="notebook_startup_success" src="https://user-images.githubusercontent.com/2721979/133989731-e912a447-1e5f-4b49-b8c7-b930c8e57a22.png">

### Failed startup
<img width="988" alt="startup_error" src="https://user-images.githubusercontent.com/2721979/133942180-32244c85-a9a0-4bd7-97de-7edaa56c5963.png">

### Successful export

#### Jupyter Lab
<img width="994" alt="export_success" src="https://user-images.githubusercontent.com/2721979/133944115-2c7afaa9-622a-4692-b847-a09259d1f2e5.png">

#### Jupyter Notebook
<img width="973" alt="notebook_export_success" src="https://user-images.githubusercontent.com/2721979/133989787-50ec7053-7fc5-4e48-a6cd-47816eb1da8b.png">

### .nbautoexport validation error
<img width="997" alt="export_error" src="https://user-images.githubusercontent.com/2721979/133944117-de92db2d-e77e-49b4-b382-d775008fc610.png">

### Export with debug mode
<img width="997" alt="export_debug" src="https://user-images.githubusercontent.com/2721979/133944119-4da27011-0d63-4994-afa2-fdf8e7cb3624.png">

## Example of CLI verbosity levels
<img width="1000" alt="cli_verbosity" src="https://user-images.githubusercontent.com/2721979/133943424-2d51a105-790f-428f-81b9-6aeb1a101899.png">

## Example of importing as library

demo_logging.py
```python
import logging
from pathlib import Path

from nbautoexport.export import export_notebook
from nbautoexport.sentinel import NbAutoexportConfig

print("---DEFAULT---")

logger = logging.getLogger()
logging.basicConfig()
export_notebook(Path("notebooks/Untitled.ipynb"), NbAutoexportConfig())

print("---INFO---")

logger.setLevel(logging.INFO)
export_notebook(Path("notebooks/Untitled.ipynb"), NbAutoexportConfig())

print("---DEBUG---")

logger.setLevel(logging.DEBUG)
export_notebook(Path("notebooks/Untitled.ipynb"), NbAutoexportConfig())
```

Output: 
```
---DEFAULT---
---INFO---
INFO:nbautoexport:nbautoexport | Exporting notebooks/Untitled.ipynb ...
---DEBUG---
INFO:nbautoexport:nbautoexport | Exporting notebooks/Untitled.ipynb ...
DEBUG:nbautoexport:nbautoexport | Using export configuration:
{
  "export_formats": [
    "script"
  ],
  "organize_by": "extension",
  "clean": {
    "exclude": []
  }
}
DEBUG:traitlets:Loading script exporter: python
DEBUG:traitlets:Applying preprocessor: TagRemovePreprocessor
DEBUG:traitlets:Applying preprocessor: RegexRemovePreprocessor
```



