### PR TITLE
Pin mkdocstrings>=0.15.2 for compatibility with mkdocs>=1.2.2. 

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8>=3.7.8
 mike
 mkdocs>=1.2.2
 mkdocs-material>=7.2.6
-mkdocstrings
+mkdocstrings>=0.15.2
 mypy>=0.782
 pip>=19.2.3
 pytest-runner>=5.1


### PR DESCRIPTION
Closes #82