### PR TITLE
Update notify job to run explicitly for push or schedule events

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,7 @@ jobs:
   notify:
     name: Notify failed build
     needs: [code-quality, tests]
-    if: failure() && github.event.pull_request == null
+    if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Before:
- Notify fail build _does not_ run for PRs

After:
- Notify fail build _does_ run for only `push` and `schedule` events

This makes it so that failed manual triggers of `workflow_dispatch` will not create a new issue. I'm thinking since we already know the build is failing, and we want to try again to check if it resolved itself, we don't need new issues. 