### PR TITLE
Add python extra for mkdocstrings

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ flake8>=3.7.8
 mike
 mkdocs>=1.2.2
 mkdocs-material>=7.2.6
-mkdocstrings>=0.15.2
+mkdocstrings[python]>=0.19.0
 mypy>=0.782
 pip>=19.2.3
 pytest-runner>=5.1


### PR DESCRIPTION
`mkdocstrings` 0.19.0 requires that the python extra be explicitly installed.

Closes #95 