### PR TITLE
Hold back setuptools to fix failing docs build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,3 +9,11 @@ exclude = '''
 )/
 | nbautoexport/_version.py
 '''
+
+[build-system]
+requires = [
+    "setuptools<=63",
+    "versioneer",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Current version of `setuptools` does not play nice with `mkdocstrings`. 