### PR TITLE
Change action used to notify failed CI builds

### DIFF
--- a/.github/failed_build_issue_template.md
+++ b/.github/failed_build_issue_template.md
@@ -1,5 +1,0 @@
----
-title: "Failed build on master branch ({{ env.WORKFLOW_NAME}} #{{ env.RUN_NUMBER }})"
-labels: bug
----
-Workflow failed: [{{ env.WORKFLOW_NAME}} #{{ env.RUN_NUMBER }}](https://github.com/{{ env.REPOSITORY }}/actions/runs/{{ env.RUN_ID }})

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,16 +145,9 @@ jobs:
   notify:
     name: Notify failed build
     needs: [code-quality, tests, integration-tests]
-    if: failure() && (github.event_name == 'push' || github.event_name == 'schedule')
+    if: failure() && github.event.pull_request == null
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: JasonEtco/create-an-issue@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          WORKFLOW_NAME: ${{ github.workflow }}
-          RUN_NUMBER: ${{ github.run_number}}
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
+      - uses: jayqi/failed-build-issue-action@v1
         with:
-          filename: .github/failed_build_issue_template.md
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR switches the failed build issue notification from a generic issue creation action to [jayqi/failed-build-issue-action](https://github.com/jayqi/failed-build-issue-action), which is an action that I wrote that is specialized for this purpose. The main difference is that additional failures will add comments to an existing open issue rather than creating a new one. 