### PR TITLE
Update canonical link for previously deployed docs

### DIFF
--- a/stable/api-reference/nbautoexport-clean/index.html
+++ b/stable/api-reference/nbautoexport-clean/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-clean/">
       
       
         <link rel="prev" href="../../command-reference/install/">

--- a/stable/api-reference/nbautoexport-export/index.html
+++ b/stable/api-reference/nbautoexport-export/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-export/">
       
       
         <link rel="prev" href="../nbautoexport-clean/">

--- a/stable/api-reference/nbautoexport-jupyter_config/index.html
+++ b/stable/api-reference/nbautoexport-jupyter_config/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-jupyter_config/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-jupyter_config/">
       
       
         <link rel="prev" href="../nbautoexport-export/">

--- a/stable/api-reference/nbautoexport-sentinel/index.html
+++ b/stable/api-reference/nbautoexport-sentinel/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-sentinel/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-sentinel/">
       
       
         <link rel="prev" href="../nbautoexport-jupyter_config/">

--- a/stable/api-reference/nbautoexport-utils/index.html
+++ b/stable/api-reference/nbautoexport-utils/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-utils/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-utils/">
       
       
         <link rel="prev" href="../nbautoexport-sentinel/">

--- a/stable/changelog/index.html
+++ b/stable/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/changelog/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../api-reference/nbautoexport-utils/">

--- a/stable/cleaning/index.html
+++ b/stable/cleaning/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/cleaning/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/cleaning/">
       
       
         <link rel="prev" href="..">

--- a/stable/command-reference/clean/index.html
+++ b/stable/command-reference/clean/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/clean/">
       
       
         <link rel="prev" href="../../cleaning/">

--- a/stable/command-reference/configure/index.html
+++ b/stable/command-reference/configure/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/configure/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/configure/">
       
       
         <link rel="prev" href="../clean/">

--- a/stable/command-reference/export/index.html
+++ b/stable/command-reference/export/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/export/">
       
       
         <link rel="prev" href="../configure/">

--- a/stable/command-reference/install/index.html
+++ b/stable/command-reference/install/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/install/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/install/">
       
       
         <link rel="prev" href="../export/">

--- a/stable/index.html
+++ b/stable/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/">
       
       
       

--- a/v0.1/api-reference/nbautoexport-clean/index.html
+++ b/v0.1/api-reference/nbautoexport-clean/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/api-reference/nbautoexport-clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/nbautoexport-export/index.html
+++ b/v0.1/api-reference/nbautoexport-export/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/api-reference/nbautoexport-export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/nbautoexport-jupyter_config/index.html
+++ b/v0.1/api-reference/nbautoexport-jupyter_config/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/api-reference/nbautoexport-jupyter_config/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-jupyter_config/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/nbautoexport-sentinel/index.html
+++ b/v0.1/api-reference/nbautoexport-sentinel/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/api-reference/nbautoexport-sentinel/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-sentinel/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/api-reference/nbautoexport-utils/index.html
+++ b/v0.1/api-reference/nbautoexport-utils/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/api-reference/nbautoexport-utils/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-utils/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/command-reference/clean/index.html
+++ b/v0.1/command-reference/clean/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/command-reference/clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/command-reference/configure/index.html
+++ b/v0.1/command-reference/configure/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/command-reference/configure/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/configure/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/command-reference/export/index.html
+++ b/v0.1/command-reference/export/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/command-reference/export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/command-reference/install/index.html
+++ b/v0.1/command-reference/install/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/command-reference/install/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/install/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.1/index.html
+++ b/v0.1/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.1/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/nbautoexport-clean/index.html
+++ b/v0.2/api-reference/nbautoexport-clean/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/api-reference/nbautoexport-clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/nbautoexport-export/index.html
+++ b/v0.2/api-reference/nbautoexport-export/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/api-reference/nbautoexport-export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/nbautoexport-jupyter_config/index.html
+++ b/v0.2/api-reference/nbautoexport-jupyter_config/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/api-reference/nbautoexport-jupyter_config/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-jupyter_config/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/nbautoexport-sentinel/index.html
+++ b/v0.2/api-reference/nbautoexport-sentinel/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/api-reference/nbautoexport-sentinel/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-sentinel/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/api-reference/nbautoexport-utils/index.html
+++ b/v0.2/api-reference/nbautoexport-utils/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/api-reference/nbautoexport-utils/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-utils/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/cleaning/index.html
+++ b/v0.2/cleaning/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/cleaning/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/cleaning/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/command-reference/clean/index.html
+++ b/v0.2/command-reference/clean/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/command-reference/clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/command-reference/configure/index.html
+++ b/v0.2/command-reference/configure/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/command-reference/configure/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/configure/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/command-reference/export/index.html
+++ b/v0.2/command-reference/export/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/command-reference/export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/command-reference/install/index.html
+++ b/v0.2/command-reference/install/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/command-reference/install/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/install/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.2/index.html
+++ b/v0.2/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.2/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/nbautoexport-clean/index.html
+++ b/v0.3/api-reference/nbautoexport-clean/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/api-reference/nbautoexport-clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/nbautoexport-export/index.html
+++ b/v0.3/api-reference/nbautoexport-export/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/api-reference/nbautoexport-export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/nbautoexport-jupyter_config/index.html
+++ b/v0.3/api-reference/nbautoexport-jupyter_config/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/api-reference/nbautoexport-jupyter_config/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-jupyter_config/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/nbautoexport-sentinel/index.html
+++ b/v0.3/api-reference/nbautoexport-sentinel/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/api-reference/nbautoexport-sentinel/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-sentinel/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/api-reference/nbautoexport-utils/index.html
+++ b/v0.3/api-reference/nbautoexport-utils/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/api-reference/nbautoexport-utils/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-utils/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/changelog/index.html
+++ b/v0.3/changelog/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/changelog/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/cleaning/index.html
+++ b/v0.3/cleaning/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/cleaning/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/cleaning/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/command-reference/clean/index.html
+++ b/v0.3/command-reference/clean/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/command-reference/clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/command-reference/configure/index.html
+++ b/v0.3/command-reference/configure/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/command-reference/configure/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/configure/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/command-reference/export/index.html
+++ b/v0.3/command-reference/export/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/command-reference/export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/command-reference/install/index.html
+++ b/v0.3/command-reference/install/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/command-reference/install/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/install/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.3/index.html
+++ b/v0.3/index.html
@@ -11,7 +11,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.3/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.2, mkdocs-material-7.2.6">

--- a/v0.4/api-reference/nbautoexport-clean/index.html
+++ b/v0.4/api-reference/nbautoexport-clean/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/api-reference/nbautoexport-clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/api-reference/nbautoexport-export/index.html
+++ b/v0.4/api-reference/nbautoexport-export/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/api-reference/nbautoexport-export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/api-reference/nbautoexport-jupyter_config/index.html
+++ b/v0.4/api-reference/nbautoexport-jupyter_config/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/api-reference/nbautoexport-jupyter_config/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-jupyter_config/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/api-reference/nbautoexport-sentinel/index.html
+++ b/v0.4/api-reference/nbautoexport-sentinel/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/api-reference/nbautoexport-sentinel/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-sentinel/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/api-reference/nbautoexport-utils/index.html
+++ b/v0.4/api-reference/nbautoexport-utils/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/api-reference/nbautoexport-utils/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-utils/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/changelog/index.html
+++ b/v0.4/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/changelog/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/changelog/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/cleaning/index.html
+++ b/v0.4/cleaning/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/cleaning/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/cleaning/">
       
       <link rel="icon" href="../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/command-reference/clean/index.html
+++ b/v0.4/command-reference/clean/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/command-reference/clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/clean/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/command-reference/configure/index.html
+++ b/v0.4/command-reference/configure/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/command-reference/configure/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/configure/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/command-reference/export/index.html
+++ b/v0.4/command-reference/export/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/command-reference/export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/export/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/command-reference/install/index.html
+++ b/v0.4/command-reference/install/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/command-reference/install/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/install/">
       
       <link rel="icon" href="../../assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.4/index.html
+++ b/v0.4/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.4/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/">
       
       <link rel="icon" href="assets/images/favicon.png">
       <meta name="generator" content="mkdocs-1.2.3, mkdocs-material-8.2.5">

--- a/v0.5/api-reference/nbautoexport-clean/index.html
+++ b/v0.5/api-reference/nbautoexport-clean/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-clean/">
       
       
         <link rel="prev" href="../../command-reference/install/">

--- a/v0.5/api-reference/nbautoexport-export/index.html
+++ b/v0.5/api-reference/nbautoexport-export/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-export/">
       
       
         <link rel="prev" href="../nbautoexport-clean/">

--- a/v0.5/api-reference/nbautoexport-jupyter_config/index.html
+++ b/v0.5/api-reference/nbautoexport-jupyter_config/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-jupyter_config/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-jupyter_config/">
       
       
         <link rel="prev" href="../nbautoexport-export/">

--- a/v0.5/api-reference/nbautoexport-sentinel/index.html
+++ b/v0.5/api-reference/nbautoexport-sentinel/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-sentinel/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-sentinel/">
       
       
         <link rel="prev" href="../nbautoexport-jupyter_config/">

--- a/v0.5/api-reference/nbautoexport-utils/index.html
+++ b/v0.5/api-reference/nbautoexport-utils/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/api-reference/nbautoexport-utils/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/api-reference/nbautoexport-utils/">
       
       
         <link rel="prev" href="../nbautoexport-sentinel/">

--- a/v0.5/changelog/index.html
+++ b/v0.5/changelog/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/changelog/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/changelog/">
       
       
         <link rel="prev" href="../api-reference/nbautoexport-utils/">

--- a/v0.5/cleaning/index.html
+++ b/v0.5/cleaning/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/cleaning/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/cleaning/">
       
       
         <link rel="prev" href="..">

--- a/v0.5/command-reference/clean/index.html
+++ b/v0.5/command-reference/clean/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/clean/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/clean/">
       
       
         <link rel="prev" href="../../cleaning/">

--- a/v0.5/command-reference/configure/index.html
+++ b/v0.5/command-reference/configure/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/configure/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/configure/">
       
       
         <link rel="prev" href="../clean/">

--- a/v0.5/command-reference/export/index.html
+++ b/v0.5/command-reference/export/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/export/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/export/">
       
       
         <link rel="prev" href="../configure/">

--- a/v0.5/command-reference/install/index.html
+++ b/v0.5/command-reference/install/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/command-reference/install/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/command-reference/install/">
       
       
         <link rel="prev" href="../export/">

--- a/v0.5/index.html
+++ b/v0.5/index.html
@@ -10,7 +10,7 @@
       
       
       
-        <link rel="canonical" href="https://nbautoexport.drivendata.org/v0.5/">
+        <link rel="canonical" href="https://nbautoexport.drivendata.org/stable/">
       
       
       


### PR DESCRIPTION
This updates the canonical link in previously deployed docs to point to the `stable` version. This will help search engine indexers know to only return results for `stable`. 

This updates the files stored on `gh-pages`, which is our staging branch. After merging, we'll need to run any CI job that pushes updated docs for the changes to then be pushed to Netlify. 